### PR TITLE
Formatting examples

### DIFF
--- a/default/de/cat_collections.md
+++ b/default/de/cat_collections.md
@@ -128,7 +128,7 @@ The first subject heading should be **Compilations** and/or **Pasticcios**. The 
 
 **Description summary (520)**  
 Use this field to describe in general the nature of the source.  
-_Example_:  
+##### Example:  
 Act 1 by Amadei, act 2 by Bononcini, overture and act 3 by Händel
 
 **Alternate title (730)**  
@@ -233,7 +233,7 @@ There are two ways to catalog periodicals that contain music: as a collection or
 
 
 **Collections** can be appropriate when the periodical consists of all or mostly music and the item was collected and preserved as a whole. Holdings are attached to the collection level. Individual entries are created for each piece in the issue.  
-_Example_:  
+##### Example:  
 1001097294: January issue (precise year unknown) of the _Kleine Pianoforte-Bibliothek_, containing 5 pieces. There is one record for the collection parent record, and five individual entries for each piece.
 
 **Single works** can be appropriate when works were included as insertions or additions to periodicals without a notated music focus. Frequently, such items are preserved outside of their original publication context.  
@@ -245,7 +245,7 @@ _Examples_:
 Erfassung von Musik in nicht-musikalischen Publikationen
 RISM enthält auch Werke, die in gedruckten Publikationen gefunden wurde, die nicht primär Musikdokumente sind. Der Schwerpunkt des RISM-Datensatzes liegt dennoch auf der Musik.   
 
-_Beispiel_:   
+##### Beispiel:   
 990026614: 3 Songs von John Isaac Hawkins, die in Charles Willson Peales _Discourse introductory to a course of lectures on the science of nature_ (1800) erschienen.  
 **Komponist/Autor (100)**: Komponist des Songs  
 **Nebeneintragung Person (700)**: Autor des Buchs mit Indikator **Sonstige Funktion**  

--- a/default/de/catalog_210.md
+++ b/default/de/catalog_210.md
@@ -26,7 +26,7 @@ Bekannte Lexika oder Reihen werden mit den allgemein gebräuchlichen Abkürzunge
 
  
   
-_Beispiele:_  
+##### Beispiele  
 
 Pieter Dirksen: Heinrich Scheidemann's Keyboard Music.Transmission, Style and Chronology, Aldershot 2007
 
@@ -58,7 +58,7 @@ Abkürzungen, die in Werkverzeichnissen benutzt werden und nicht zu Verwechlsung
 
   
   
-_Beispiele:_  
+##### Beispiele  
 
 Walter Knape: Bibliographisch-thematisches Verzeichnis der Kompositionen von Karl Friedrich Abel (1723-1787), Cuxhaven 1971 
 

--- a/default/de/help_titles_keywords.md
+++ b/default/de/help_titles_keywords.md
@@ -14,7 +14,7 @@ Die Termini erscheinen in der Regel im Plural. Bei gleichen Schlagworten für Vo
 Können bei einem Werk mehrere Schlagworte vergeben werden, liegt es im Ermessen des Bearbeiters, die Reihenfolge derselben festzulegen. Es gibt Werke, die auf jeden Fall mehrere weitere Schlagworte mit sich ziehen wie beispielsweise "Contrafacta" oder "Inserts".  
 
 
-_Beispiele:_
+##### Beispiele
 
 1.      Choralarrangement mit bekanntem Textincipit  
 In diesem Fall ist diese Liste nicht notwendig! Das Textincipit des Chorals wird zum Einordnungstitel mit dem Zusatz **Arrangement**. Als Schlagwort dient **Chorale**  **arrangements**.

--- a/default/de/institution_680.md
+++ b/default/de/institution_680.md
@@ -7,7 +7,7 @@ Hier können allgemeine Angaben über die Bibliothek oder Körperschaft gemacht 
 - URL z. B. von Onlineressourcen der Bibliothek oder Körperschaft
 - Liste der Bestandsführung (ISDIAH 5.3.7): Einträge der Namen geschlossener Bestände und Sammlungen in der Bibliothek oder Körperschaft. Jeder Name erhält eine eigene Zeile normiert nach den Konventionen der Bibliothek. Bei Nach- und Vorlässen von Personen ist es wünschenswert auch die Lebensdaten in runden Klammern anzuhängen. Zusätzlich kann jeweils eine URL angegeben werden.    
   
-_Beispiele:_ Joachim, Joseph (1831-1907) (Royal College of Music, Library)  
+##### Beispiele Joachim, Joseph (1831-1907) (Royal College of Music, Library)  
 Andrée-Stenhammararkivet  
 Telemann, Georg Michael  
 Fonds Montpensier  

--- a/default/de/publication_022.md
+++ b/default/de/publication_022.md
@@ -2,7 +2,7 @@
   
 Geben Sie die Internationale Standardnummer für fortlaufende Sammelwerke (ISSN) ein. Die ISSN dient der Identifizierung von Zeitschriften und Schriftenreihen.   
   
-_Beispiele:_  
+##### Beispiele  
     
 0027-4380  
 0003-0139  

--- a/default/de/publication_024.md
+++ b/default/de/publication_024.md
@@ -2,6 +2,6 @@
   
 Geben Sie hier die Internationale Standardnummer für Musikalien (ISMN) ein. Die ISMN dient der Identifizierung von Musiknoten.  
   
-_Beispiele:_  
+##### Beispiele  
 979-0-9020000-9-3  
 M-2306-7118-7

--- a/default/de/publication_210.md
+++ b/default/de/publication_210.md
@@ -26,7 +26,7 @@ Bekannte Lexika oder Reihen werden mit den allgemein gebräuchlichen Abkürzunge
 
  
   
-_Beispiele:_  
+##### Beispiele  
 
 Pieter Dirksen: Heinrich Scheidemann's Keyboard Music.Transmission, Style and Chronology, Aldershot 2007
 
@@ -58,7 +58,7 @@ Abkürzungen, die in Werkverzeichnissen benutzt werden und nicht zu Verwechlsung
 
   
   
-_Beispiele:_  
+##### Beispiele  
 
 Walter Knape: Bibliographisch-thematisches Verzeichnis der Kompositionen von Karl Friedrich Abel (1723-1787), Cuxhaven 1971 
 

--- a/default/de/publication_250.md
+++ b/default/de/publication_250.md
@@ -1,6 +1,6 @@
 #### Ausgabebezeichnung (250)
   
-_Beispiele:_  
+##### Beispiele  
 
 1. Auflage
 

--- a/default/de/publication_650.md
+++ b/default/de/publication_650.md
@@ -4,7 +4,7 @@ Tragen Sie hier Schlagwörter / Deskriptoren für die inhaltliche Erschließung 
   
 Geographische Begriffe werden im Feld **Orte (651)**eingetragen.  
   
-_Beispiele:_  
+##### Beispiele  
 Instruments   
 Madrigals   
 Schriftsteller   

--- a/default/de/publication_710.md
+++ b/default/de/publication_710.md
@@ -8,6 +8,6 @@ Verwenden Sie nur folgende Funktionen:
 
 - **Editor**: Speziell wenn es sich um die Herausgabe durch eine Körperschaft handelt.  
 
-_Beispiele:_  
+##### Beispiele  
 Sing-Akademie zu Berlin   
 Historische Sektion der Bayerischen Benediktinerakademie

--- a/default/de/publication_760.md
+++ b/default/de/publication_760.md
@@ -14,5 +14,5 @@ _Beispiele_:
 vol. 3/1-2; 11/1-2  
   
 Bei Aufsätzen in einem Sammelband werden hier die Seitenzahlen genannt:  
-_Beispiel_:  
+##### Beispiel:  
 p. 76-109

--- a/default/de/publication_856.md
+++ b/default/de/publication_856.md
@@ -7,7 +7,7 @@ Verlinkung zu elektronischen Ressourcen. Verwenden Sie möglichst Permalinks.
 Geben Sie eine kurze Beschreibung der URL.
 
   
-_Beispiele:_  
+##### Beispiele  
 Electronic resource  
 Elektronische Ressource  
 Link to PDF  

--- a/default/de/source_026.md
+++ b/default/de/source_026.md
@@ -8,7 +8,7 @@ Geben Sie hier den zusammenhängenden Fingerprint an.
 
 Die Richtlinien des Institut de Recherche et d’Histoire des Texte und der National Library of Scotland können online eingesehen werden: [Englisch, Französisch und Italienisch](http://edit16.iccu.sbn.it/web_iccu/info/en/Impronta_notiziario.htm) sowie [Deutsch](https://katalogbeta.slub-dresden.de/id/0001617101/#detail).
 
-_Beispiel_:  
+##### Beispiel:  
 n?n, n;t, v.at BeDr C 1695R
 
 Weiterhin stehen folgende Felder zur Verfügung.  

--- a/default/de/source_031.md
+++ b/default/de/source_031.md
@@ -9,7 +9,7 @@ Die Incipitnummer besteht aus drei durch Punkte getrennte Zahlen, welche für da
 
 Die Nummerierung ist immer fortlaufend, auch wenn einzelne Sätze fehlen.
 
-_Beispiele:_  
+##### Beispiele  
 1.1.1 = 1. Werk, 1. Satz, 1. Incipit  
 1.1.2 = 2. Incipit zum 1. Satz im 1. Werk (erklingt gleichzeitig mit 1.1.1)  
 1.2.1 – 1. Werk, 2. Satz, 1. Incipit
@@ -159,7 +159,7 @@ Geben Sie keine Bindebögen ein.
 { = Balkungsbeginn  
 } = Balkungsende
 
-_Beispiel_:  
+##### Beispiel:  
 {qq6'CDEDr}
 
 **10. Sonderrhythmen:**  
@@ -197,7 +197,7 @@ _Beispiel:_
 11.3. Rhythmisches Muster  
 Wenn sich eine rhythmische Abfolge mehrmals wiederholt, kann sie den betroffenen Tonbuchstaben als rhythmisches Muster vorangestellt werden.
 
-_Beispiel_:  
+##### Beispiel:  
 statt 8.A6B8C8.D6E8F kann stehen 8.68ABCDEF  
 Das rhythmische Muster endet, sobald ein anderer rhythmischer Wert folgt.  
   
@@ -206,7 +206,7 @@ Das rhythmische Muster endet, sobald ein anderer rhythmischer Wert folgt.
 
 Verwenden Sie % für Schlüsselwechsel, $ für Vorzeichenwechsel und @ für Taktwechsel. Der veränderten Globalangabe muss ein Leerzeichen folgen.
 
-_Beispiele:_  
+##### Beispiele  
 %C-1 '2A  
 %C-1 $xFC '8B  
 @3/2 '1C  
@@ -271,6 +271,6 @@ weitere Instrumente.
 
 Genannt werden die Stimmen jeweils von der höchsten zur tiefsten Stimmlage, durch Komma getrennt. Die jeweiligen Stimmgruppen werden durch Semikolon getrennt. Ergänzungen können durch eckige Klammern angezeigt werden.
 
-_Beispiele:_   
+##### Beispiele   
 S (Enrico), T (Vanoldo); vl 1, 2, b; [winds]  
 S 2 solo; Coro; ob obl; strings, bc

--- a/default/de/source_240.md
+++ b/default/de/source_240.md
@@ -24,7 +24,7 @@ Geben Sie den Titel entsprechend der Schreibweise in 1) New Grove, 2) MGG, 3) We
 
 Titel von Drucken und populäre Namen (wie „Eroica“ oder „Nelson-Messe“ etc.) gelten nicht als Einordnungstitel. Solche Namen werden in **Alternativer Einordnungstitel (730 $a)** eingegeben.
 
-_Beispiele:_  
+##### Beispiele  
 Die Forelle  
  Die Zauberflöte  
  The beggar's opera
@@ -42,14 +42,14 @@ Die Groß- und Kleinschreibung richten sich nach den Regeln der jeweiligen Sprac
 
 Das Textinicipit muss mit demjenigen im Feld **Textincipit (031 $t)** in Schreibweise und Länge übereinstimmen. Lateinische Textincipits werden hier allerdings nur bis zu dem Trennungszeichen (Komma) als Einordnungstitel verwendet (siehe auch Liste im Anhang). 
 
-_Beispiele:_  
+##### Beispiele  
 Der Mond ist aufgegangen  
  Gloria [mit dem Textincipit: Gloria, in excelsis Deo et in terra pax]
 
 **3. Gattungsbezeichnungen**  
 Kommen weder Individualtitel noch Textincipit als Einordnungstitel in Frage, wird hier die entsprechende Gattung eingetragen. Der Gattungsbegriff als Einordnungstitel wird in der Regel englischsprachig und im Plural angesetzt (Beispiel: **Operas**). Bei einem Gattungsbegriff als Einordnungstitel korrespondiert dieser zumeist mit dem **Schlagwort (650)**. Bitte benutzen Sie die Arbeitshilfe **Einordnungstitel - Schlagworte** im Anhang der **Richtlinien**.
 
-_Beispiele:_  
+##### Beispiele  
 Symphonies  
  Allemandes
 
@@ -60,7 +60,7 @@ Lässt sich keine Gattung ermitteln, so kann auch eine Tempobezeichnung als Eino
 -Movements (Einzelsatz eines unbestimmten Instrumentalstücks ohne Tempobezeichnung)
 
   
-_Beispiele:_    
+##### Beispiele    
 Presto  
 Lento  
   
@@ -68,7 +68,7 @@ Lento
 **Besondere Regelungen:**
 
 - **Collections**: für den Einordnungstitel gelten für Sammlungen (Collections), Konvolute und Variationen. In diesen Fällen wird dem Gattungsbegriff eine arabische Zahl vorangestellt, die die Anzahl der zugehörigen Werke bezeichnet.  
-_Beispiele:_  
+##### Beispiele  
 25 Arias  
 3 Instrumental pieces
 

--- a/default/de/source_260.md
+++ b/default/de/source_260.md
@@ -28,7 +28,7 @@ Bei den Handschriften sollte möglichst immer eine (annähernde) Datierung gemac
 
 Daten können in einer der Katalogisierungssprachen durch folgende Begriffe ergänzt werden: **ca.** (für circa) **, nach, vor.** Mit Fragezeichen wird die Fragwürdigkeit einer Angabe angezeigt. Das Entstehungsjahr sollte möglichst exakt angegeben werden. Bei Unsicherheit können auch größere Zeiträume gewählt werden.
 
-_Beispiele:_  
+##### Beispiele  
 1875  
 1856 Weihnachten  
 1757-01-11  

--- a/default/de/source_300.md
+++ b/default/de/source_300.md
@@ -38,7 +38,7 @@ Dirigierstimmen werden als **conductor part** im Feld **Vorhandenes Stimmenmater
   
 **Umfang:** Durch Doppelpunkt getrennt folgen die Paginierungsabkürzungen: „f.“ für folio (Folio), „p.“ für pagina (Seite), „lvs.“ für leaves (Papierbogen) und „fds.“ für folds (Lagen). Bei Einzeleinträgen von Collections/Konvoluten wird die genaue Seitenzahl, auf welchen sich das entsprechende Werk befindet, angegeben, wobei der Indikator „p.“ bzw. „f.“ bzw. „lvs.“ bzw. „fds.“ vorangestellt wird.
 
-_Beispiele:_  
+##### Beispiele  
 1 score: 35 p.  
 1 short score: 8 f.  
 1 tablature score: p. 5-8  

--- a/default/de/source_506.md
+++ b/default/de/source_506.md
@@ -2,6 +2,6 @@
 
 Hier werden Benutzungsbestimmungen der entsprechenden Institution in einer der Katalogisierungssprachen eingetragen.
 
-_Beispiele:_  
+##### Beispiele  
 Konsultation nur im Lesesaal.  
 Reproduktionen nur auf Anfrage (ggfl. gegen Gebühr).

--- a/default/de/source_588.md
+++ b/default/de/source_588.md
@@ -6,14 +6,14 @@ In diesem Feld wird angegeben, nach welchem Exemplar die bibliographische Beschr
 
 Geben Sie das Bibliothekssigel und die Signatur des verwendeten Drucks an. Sie können auch angeben, ob Sie das Exemplar nur für einen Teil der Beschreibung verwendet haben.
 
-_Beispiele:_
+##### Beispiele
 
 - CZ-Nlob X A a 12
 - (Incipits:) US-BETm LCM 242
 
 Wenn Sie eine zweite Quelle als Grundlage für den Datensatz verwenden, füllen Sie dieses Feld wie gewohnt aus, nennen die zweite Quelle auch in **Bemerkungen (500)** und verweisen auf Literatur oder ein Werkverzeichnis.
 
-_Beispiele:_
+##### Beispiele
 
 - **Vorlageexemplar** **(588)**: GB-Lbl h.11.a.(1.)
 - **Bemerkungen (500)**: Record based on YouV using the description of the copy in GB-Lbl, shelfmark h.11.a.(1.).

--- a/default/de/source_594.md
+++ b/default/de/source_594.md
@@ -48,7 +48,7 @@ Generalbass
 
 Genannt werden die Stimmen jeweils von der höchsten zur tiefsten Stimmlage, möglichst jeweils eine Stimmbezeichnung pro Zeile. Alternativbesetzungen werden in Klammern der originalen Besetzung angehängt.
 
-_Beispiele:_  
+##### Beispiele  
 S  
 A  
 T  
@@ -72,7 +72,7 @@ org
 
 Hier wird die Anzahl der jeweiligen Stimmen angegeben. Sind zwei Stimmen des gleichen Instruments beteiligt, erfolgt die Bezeichnung im Feld **Besetzung** und hier im Feld **Anzahl** die Angabe  **2**.
 
-_Beispiele:_  
+##### Beispiele  
 vl         2 [für ein Werk mit Violine 1 und Violine 2]  
 vla        1 [nur 1 Violastimme]  
 ob        2 [Oboe 1 und Oboe 2]  

--- a/default/de/source_597.md
+++ b/default/de/source_597.md
@@ -2,5 +2,5 @@
 
 Bei den Drucken wird hier der Kolophon (Schlussformel mit Angaben über Verfasser, Druckort und Druckjahr) wie auf der Quelle wiedergegeben.
 
-_Beispiel_:  
+##### Beispiel:  
 Vigilie maiores minoresqz ac vespere mortuorū:ānexis officijs | eorundem expliciunt feliciter. Anno dñi.M.cccc.xcij.kł.ij.aprilis

--- a/default/de/source_651.md
+++ b/default/de/source_651.md
@@ -4,6 +4,6 @@ Ein Aufführungsort wird angegeben, wenn er auf der Quelle erscheint. Die Angabe
 
 Bei Musikdrucken werden hier nur Angaben gemacht, wenn es sich um einen Gelegenheitsdruck handelt. Ortsangaben, die sich auf ein bestimmtes Exemplar des Drucks beziehen, werden im Exemplareintrag gemacht.
 
-_Beispiele:_  
+##### Beispiele  
 Praha  
 Milano

--- a/default/de/source_657.md
+++ b/default/de/source_657.md
@@ -2,7 +2,7 @@
 
 Hier werden Hinweise auf die liturgische Verwendung der Komposition gegeben. Dazu zählen die Sonntage des Kirchenjahres, andere liturgische Festtage, Feiertage, die Advents- oder Weihnachtszeit etc. Das Feld ist mit der Normdatei **Liturgische Feste** verknüpft. Wenden Sie sich an die Zentralredaktion, sofern ein liturgisches Fest nicht vorhanden ist.
 
-_Beispiele:_  
+##### Beispiele  
 Nativitas Domini  
 Mariae (B.V.) Visitatio  
 Single Sisters Covenant Day (Moravian Church)

--- a/default/de/source_852.md
+++ b/default/de/source_852.md
@@ -12,7 +12,7 @@ Geben Sie das Bibliothekssigel der besitzenden Institution an. Dieses Feld ist m
 
 Genaue Standortangabe bei großen Bibliotheken. Geben Sie die Bezeichnung in der Landessprache ein. In Klammern kann eine Übersetzung in einer der Katalogisierungssprachen gegeben werden. 
 
-_Beispiele:_  
+##### Beispiele  
 Musikabteilung  
  Music Department   
 Collezioni speciali  
@@ -22,7 +22,7 @@ Zakład Zbiorów Muzycznych [Music department]
 
 Vorgesehen für Nachlässe, geschlossene Provenienzen und Sammlungen o.ä.. Geben Sie die Bezeichnung in der Landessprache ein. In Klammern kann eine Übersetzung in einer der Katalogisierungssprachen gegeben werden.
 
-_Beispiel_:  
+##### Beispiel:  
 Sammlung Hanns J. Eller
 
 Achtung: Geben Sie Provenienzvermerke im Feld **Herkunft der Quelle (561)** ein.
@@ -31,7 +31,7 @@ Achtung: Geben Sie Provenienzvermerke im Feld **Herkunft der Quelle (561)** ein.
 
 Dieses Feld steht nur im Exemplareintrag für Musikdrucke zur Verfügung. Ist Ihr Exemplar unvollständig, geben Sie hier die vorhandenen Stimmen (mit RISM-Abbkürzungen) oder Bände an. Ist Ihr Exemplar unvollständig, können Sie hier **komplett** schreiben. Vollständigkeit bezieht sich hier auf das Vorhandensein aller erwarteten Stimmen oder Bände. Wenn beispielsweise einzelne Seiten fehlen, geben Sie dies in einer Bemerkung an.
 
-_Beispiele:_  
+##### Beispiele  
 vl only  
 Coro S, A, B only  
 vol. 1, 3 only  
@@ -42,7 +42,7 @@ complete
 
 In dieses Feld wird die Signatur eingetragen. Die Signatur ist möglichst genau wiederzugeben (betrifft Leer- und Interpunktionszeichen). Hochstellungen werden mit **|** (Vertikalstrich) direkt vor dem entsprechenden Zeichen angegeben. Innerhalb eines Bestandes sollen die Signaturen formal einheitlich geschrieben werden. Wenn keine Signatur angegeben ist, erfolgt die Eingabe **[without shelfmark]**. Weitere Signaturen werden im Feld **Weitere Signatur (591)** eingetragen.
 
-_Beispiele:_  
+##### Beispiele  
 Ms Mus 165/6  
 Mus.ms. 743  
 Th.mus.A 5  

--- a/default/de/source_856.md
+++ b/default/de/source_856.md
@@ -11,7 +11,7 @@ Angabe einer persistenten URL.
 Pflichtfeld, wenn Sie einen Link zu einer externen Ressource eingeben.   
 Geben Sie eine kurze Beschreibung zur Erläuterung, warum die URL für die beschriebene Quelle relevant ist. Verwenden Sie Ihre Katalogisierungssprache.
 
-_Beispiele:_  
+##### Beispiele  
 Digital copy  
 Wasserzeichen auf p. 4  
 Projektwebseite  
@@ -28,15 +28,15 @@ Pflichtfeld, wenn auf eine elektronischen Ressource verlinkt wird. Wählen Sie e
 
 - **Notendigitalisat**: Der Link führt zu einer externe Webseite mit einer digitalisierten Version der im Titel vorliegenden Quelle.   
 Bevorzugt wird immer die digitale Sammlung der besitzenden Institution, dann externe Repertorien (Internet Archive oder IMSLP). Bei Sammlungen ist es nicht notwendig, den Lihk in den Teileinträgen zu wiederholen.  
-_Beispiel_:  
+##### Beispiel:  
 [https://mirador.acdh.oeaw.ac.at/musikarchivspitz/A-SPD\_A15](https://mirador.acdh.oeaw.ac.at/musikarchivspitz/A-SPD_A15/)  
 
 - **IIIF manifest**: Das verknüpfte Objekt ist ein maschinenlesbares JSON-Objekt, das von einem internen Dokumentbetrachter wie diva.js verarbeitet wird. Das Dokument ist dirket in die Webseite eingebettet. In vielen Fällen erscheint "manifest", "iiif" oder Ähnliches im Link.  
-_Beispiel_:  
+##### Beispiel:  
 [https://iiif.lib.harvard.edu/manifests/drs:2820650](https://iiif.lib.harvard.edu/manifests/drs:2820650)
 
 Wenn sowohl Links zu einem externen Dokumentbetrachter als auch ein IIIF-Manifest verfügbar sind, wiederholen Sie das Feld und führen Sie beide Links einzeln auf.  
-_Beispiel_:
+##### Beispiel:
 
 - **Externe Ressource**: [http://nrs.harvard.edu/urn-3:FHCL.Loeb:537966](http://nrs.harvard.edu/urn-3:FHCL.Loeb:537966)  
 **Fußnote**: digitized version  

--- a/default/en/cat_collections.md
+++ b/default/en/cat_collections.md
@@ -120,7 +120,7 @@ The first subject heading should be **Compilations** and/or **Pasticcios**. The 
 
 **Description summary (520)**  
 Use this field to describe in general the nature of the source.  
-_Example_:  
+##### Example:  
 Act 1 by Amadei, act 2 by Bononcini, overture and act 3 by Händel
 
 **Alternate title (730)**  
@@ -240,7 +240,7 @@ Always strive to catalog the printed material in a separate record, because it i
 There are two ways to catalog periodicals that contain music: as a collection or as a single work. In either case, the title of the periodical, with the issue number and year, is entered in the field **Additional title (730)**.
 
 **Collections** can be appropriate when the periodical consists of all or mostly music and the item was collected and preserved as a whole. Holdings are attached to the collection level. Individual entries are created for each piece in the issue.  
-_Example_:  
+##### Example:  
 1001097294: January issue (precise year unknown) of the _Kleine Pianoforte-Bibliothek_, containing 5 pieces. There is one record for the collection parent record, and five individual entries for each piece.
 
 **Single works** can be appropriate when works were included as insertions or additions to periodicals without a notated music focus. Frequently, such items are preserved outside of their original publication context.  
@@ -252,7 +252,7 @@ _Examples_:
 
 RISM includes music found in printed publications that are not primarily music documents. The focus of the RISM record is nevertheless the music.  
 
-_Example_:  
+##### Example:  
 990026614: 3 songs by John Isaac Hawkins that were published in Charles Willson Peale's _Discourse introductory to a course of lectures on the science of nature_ (1800).  
 **Composer/Author (100)**: The composer of the music  
 **Additional Personal Name (700)**: The author of the book, with the indicator **other**  

--- a/default/en/cat_printed.md
+++ b/default/en/cat_printed.md
@@ -92,7 +92,7 @@ PLATTNER à ROTTERDAM." **New record required** (different publication status). 
       Frequent changes include _v_ to _u_, _i_ to _j_ , _y_ to _i_, and _uu_ to _w_. The Editorial Center can assist with
       unfamiliar foreign languages. Additional variations can be entered in the field **Additional title (730)**.
 
-   _Examples:_
+   ##### Examples
 
    - RISM A/I: RR 3030c
       - Title on source: Musicalische Grab=schrifft.
@@ -103,7 +103,7 @@ PLATTNER à ROTTERDAM." **New record required** (different publication status). 
       statement of the author, instrumentation, number, or imprint. Sometimes a distinctive title appears on a page other
       than the title page.
 
-   _Examples:_
+   ##### Examples
 
    - RISM A/I: B 805
       - Title on source: Vezzo di perle musicali modernamente conteste alla regia sposa effigiata nella sacra cantica; opera

--- a/default/en/institution_110.md
+++ b/default/en/institution_110.md
@@ -48,7 +48,7 @@ _Examples_:
 
 In the case of private collections, the last name of the owner is added to the city code in lowercase letters.
 
-_Example_:
+##### Example:
 
 - I-PEbattisti = Italy, Perugia, Biblioteca privata Renzo Battisti.
 

--- a/default/en/institution_551.md
+++ b/default/en/institution_551.md
@@ -4,6 +4,6 @@
 
 Enter geographical names. This field is linked to the **Places** index.
 
-_Example_:
+##### Example:
 
 - Aigen-Schlägl _for the RISM library siglum record A-SCH_

--- a/default/en/institution_680.md
+++ b/default/en/institution_680.md
@@ -12,7 +12,7 @@ Enter additional notes that describe the institution, such as:
   square brackets the dates of birth and death of the person in question. If there are lists or URLs with the information about
   the collections or fonds of a specific institution, provide the URL.
 
-_Examples:_  
+##### Examples  
  - Joachim, Joseph (1831-1907) (Royal College of Music, Library)  
  - Andrée-Stenhammararkivet  
  - Telemann, Georg Michael  

--- a/default/en/publication_020.md
+++ b/default/en/publication_020.md
@@ -3,6 +3,6 @@
 #### ISBN (020 $a)
 Enter the International Standard Book Number (ISBN). The ISBN is a number consisting of 10 or 13 digits.
 
-_Examples:_  
+##### Examples  
 - 3-486-21584-1  
 - 978-3-486-21584-1

--- a/default/en/publication_022.md
+++ b/default/en/publication_022.md
@@ -4,7 +4,7 @@
 
 Enter the International Standard Serial Number (ISSN). The ISSN uniquely identifies serial publications.
 
-_Examples:_
+##### Examples
 
 - 0027-4380
 - 0003-0139

--- a/default/en/publication_024.md
+++ b/default/en/publication_024.md
@@ -3,7 +3,7 @@
 #### ISMN (024 $a)
 Enter the International Standard Music Number (ISMN). The ISMN is a unique identifier for printed music.
 
-_Examples:_
+##### Examples
 
 - 979-0-9020000-9-3
 - M-2306-7118-7

--- a/default/en/publication_210.md
+++ b/default/en/publication_210.md
@@ -19,7 +19,7 @@ Short titles for **general secondary literature** are made up as follows:
 - **Space**
 - **Year** of publication
 
-_Examples:_
+##### Examples
 > Pieter Dirksen, _Heinrich Scheidemann’s Keyboard Music: Transmission, Style and Chronology_ (Aldershot: Ashgate, 2007).  
 > → DirksenS 2007  
 > Peter Wollny, “Zur stilistischen Entwicklung des geistlichen Konzerts in der Nachfolge von Heinrich Schütz,” _Schütz-Jahrbuch_ 23 (2001): 7-32.  
@@ -32,7 +32,7 @@ _Examples:_
 
 For authors or editors who publish multiple articles about the same composer or multiple works by the same composer, a
 letter (**a**, **b**, **c**, etc.) is added to the end of the year.  
-_Examples:_
+##### Examples
 
 > Anton Cajetan Adlgasser, _Litaniae de venerabili altaris sacramento in B-Dur (WV 3.53),_ ed. Armin Kircher (Stuttgart: Carus, 2005).  
 > → KircherA 2005  
@@ -93,7 +93,7 @@ No year is needed.
 A catalog that is published as a part of a larger item, such as an appendix in a book, may be entered as a catalog of
 works. Such items can also be cited as a **Bibliographic reference (691)**.
 
-_Examples:_
+##### Examples
 
 > A. Craig Bell, _Handel: Chronological Thematic Catalogue_ (Darley: Grain-Aig Press, 1972).  
 > → BelH  
@@ -123,7 +123,7 @@ touch on other topics or not be extensive in their scope. Always double-check. I
 as for a catalog of works. If it’s the latter, give it a short title like you do for normal literature. In short,
 anything that isn’t a catalog of works is assigned a literature short title.
 
-_Examples:_
+##### Examples
 
 > Walter Pass, _Thematischer Katalog sämtlicher Werke Jacob Regnarts (ca. 1540-1599)_ (Vienna: Böhlau, 1969).  
 > → PasJ  

--- a/default/en/publication_250.md
+++ b/default/en/publication_250.md
@@ -3,7 +3,7 @@
 #### Edition statement (250 $a)
 Enter the edition statement as given on the title page.
 
-_Examples:_
+##### Examples
 
 - Auflage Partitur, zugleich Orgelstimme
 - New ed., rev. and enl.  

--- a/default/en/publication_502.md
+++ b/default/en/publication_502.md
@@ -4,7 +4,7 @@
 
 If the item is a doctoral dissertation, include the type of degree, institution, and year.
 
-_Examples:_
+##### Examples
 
 - Ph.D. diss., University College, London 1998
 - Diss., Freie Universität, Berlin 2002

--- a/default/en/publication_650.md
+++ b/default/en/publication_650.md
@@ -8,7 +8,7 @@ file.
 
 Geographic locations are entered in the field **Related place (651)**.
 
-_Examples:_
+##### Examples
 
 - Instruments
 - Madrigals

--- a/default/en/publication_710.md
+++ b/default/en/publication_710.md
@@ -7,7 +7,7 @@ this field. This field is linked to the **Institutions** authority file.
 - **Editor**: Use especially if the item has an institution as an author rather than people.
 - **Other function**
 
-_Examples:_
+##### Examples
 
 - Sing-Akademie zu Berlin
 - Historische Sektion der Bayerischen Benediktinerakademie

--- a/default/en/publication_760.md
+++ b/default/en/publication_760.md
@@ -22,7 +22,7 @@ _Examples_:
 
 For a chapter within a collection of essays, enter the page numbers of the chapter:  
 
-_Example_:
+##### Example:
 
 - p. 76-109
 

--- a/default/en/publication_856.md
+++ b/default/en/publication_856.md
@@ -8,7 +8,7 @@ Enter the full URL of the external resource. Use permalinks whenever possible.
 
 Enter a brief note that describes the link.
 
-_Examples:_
+##### Examples
 
 - Electronic resource
 - Elektronische Ressource

--- a/default/en/source_026.md
+++ b/default/en/source_026.md
@@ -11,7 +11,7 @@ Guidelines established by the Institut de Recherche et d’Histoire des Texte an
 consulted online in [English, French, and Italian](http://edit16.iccu.sbn.it/web_iccu/info/en/Impronta_notiziario.htm),
 and [German](http://nbn-resolving.de/urn:nbn:de:hbz:6:1-195591).
 
-_Example_:  
+##### Example:  
 n?n, n;t, v.at BeDr C 1695R
 
 Other fields are also available, depending on the description standard:

--- a/default/en/source_031.md
+++ b/default/en/source_031.md
@@ -113,7 +113,7 @@ Enter **x** for sharp keys or **b** for flat keys, followed by capital letters o
 If a piece is clearly in a certain key but a sharp or flat is not in the key signature, the missing sharps or flats may
 be added in square brackets. If there is no key signature, leave the field blank.
 
-_Examples:_
+##### Examples
 
 - xF = F is sharp = G major or E minor
 - bBE = B and E are flat = B-flat major or G minor
@@ -251,7 +251,7 @@ The total duration value of the group must be written before the **(**. The rhyt
 given after **(**, even if it is identical with that of the note immediately before the section of special rhythm. The
 number of notes in the group must be indicated before **)**. It is separated from the last note by **;**.
 
-_Examples:_
+##### Examples
 
 - 8(3ABCDE;5)   = quintuplet, five demisemiquavers/32nd notes, in the space of a quaver/eighth note.
 - 8({3ABCDE};5) = quintuplet, five demisemiquavers/32nd notes, in the space of a quaver/eighth note, beamed
@@ -302,7 +302,7 @@ _Example:_
 Use **%** to change the clef, **$** to change the key, and **@** to change the time signature. Follow this with the new
 indication (clef, key, or time), followed by a space.
 
-_Examples:_
+##### Examples
 
 - %C-1 '2A
 - %C-1 $xFC '8B
@@ -314,7 +314,7 @@ _Examples:_
 Abbreviated forms of notation found within the music, such as tremolos or simile signs for repeats, must be written out
 in full using the actual notation.
 
-_Examples:_
+##### Examples
 
 - {'8DDDD} = minim/ half tremolo on D
 
@@ -337,7 +337,7 @@ In this field, you can indicate the specific scoring for the particular movement
 a complex vocal piece). List the scoring on one line using RISM instrument abbreviations and in the standard order (
 described in **Scoring summary [240 $m]**). Use a semicolon to separate instrument families.
 
-_Examples:_
+##### Examples
 
 - S (Enrico), T (Vanoldo); vl 1, 2, b; [winds]
 - S 2 solo; Coro; ob obl; strings, bc

--- a/default/en/source_240.md
+++ b/default/en/source_240.md
@@ -27,7 +27,7 @@ reference books. Do not omit initial articles (the, a, an, der, die, le, l', etc
 Popular names or nicknames (such as "Eroica" or "Nelson Mass") do not count as standardized titles. Such names are
 entered in the field **Additional titles (730 $a)**.
 
-_Examples:_  
+##### Examples  
  - Die Forelle  
  - Die Zauberflöte  
  - The beggar's opera
@@ -54,7 +54,7 @@ Make sure that the text incipit in this field is identical with the text incipit
 With Latin texts, use the text that precedes the comma (from the list in the appendix) as a standardized title but use
 the text incipit in its entirety for the text incipit.
 
-_Examples:_  
+##### Examples  
  - Der Mond ist aufgegangen  
  - Gloria [with text incipit: Gloria, in excelsis Deo et in terra pax]
 
@@ -64,7 +64,7 @@ _Examples:_
    corresponding **Subject heading (650)** is used. Please consult the appendix **Standardized title – Subject heading**
    in the **Guidelines** for assistance.
 
-_Examples:_  
+##### Examples  
  - Symphonies  
  - Allemandes
 
@@ -75,7 +75,7 @@ _Examples:_
    -Pieces (a generic piece)  
    -Movements (a single movement of an instrumental piece without a tempo indication and of indeterminate character)
 
-_Examples:_  
+##### Examples  
  - Presto  
  - Lento
 
@@ -83,7 +83,7 @@ _Examples:_
 
 - **Collections**. In these cases, a number plus the genre is entered. Enter an arabic numeral indicating how many
   works belong to the collection, followed by a genre that is as comprehensive as possible.  
-  _Examples:_    
+  ##### Examples    
   25 Arias  
   3 Instrumental pieces
 - **Composite volumes**. Enter a number corresponding to the number of items involved plus the word "Items."  

--- a/default/en/source_260.md
+++ b/default/en/source_260.md
@@ -52,7 +52,7 @@ Note that for manuscripts, dates are given without square brackets because manus
 
 Other dates may be indicated as on the source. Use question marks to indicate uncertain information.
 
-_Examples:_  
+##### Examples  
  - 1875
  - 1856 Christmas Day  
  - 1757-01-11  

--- a/default/en/source_340.md
+++ b/default/en/source_340.md
@@ -28,7 +28,7 @@ Any additions or comments about the printing technique may be explained in the f
 If a source includes multiple printing techniques, you may repeat the field to indicate each technique. Include a note
 in the field **General note (500 $a)** to explain.
 
-_Example_:
+##### Example:
 
 Engraved music that has a lithographed title page:
 

--- a/default/en/source_506.md
+++ b/default/en/source_506.md
@@ -3,7 +3,7 @@
 #### Access restrictions (506 $a)
 Terms and conditions of the holding institution can be entered here. Enter using your cataloging language.
 
-_Examples:_  
+##### Examples  
 
 - Consultation in the reading room.  
 - Reproductions upon request (charges may apply).

--- a/default/en/source_588.md
+++ b/default/en/source_588.md
@@ -8,7 +8,7 @@ records).
 Enter the library siglum and shelfmark of the printed edition consulted. You can also indicate if you used a copy for
 only a portion of the record, such as incipits or individual entries.
 
-_Examples:_
+##### Examples
 
 - CZ-Nlob X A a 12
 - (incipits:) US-BETm LCM 242

--- a/default/en/source_594.md
+++ b/default/en/source_594.md
@@ -47,7 +47,7 @@ List the scoring in the following order:
 List parts from the highest to the lowest range. Enter one instrument per line. Add alternative scoring possibilities to
 the original requirements in square brackets.
 
-_Examples:_
+##### Examples
 
 - S
 - A
@@ -71,7 +71,7 @@ _Examples:_
 Indicate the total number of parts here. If a piece includes two parts for the same instrument, enter the single
 instrument in the field **Scoring** and **2** in the field **Number**.
 
-_Examples:_
+##### Examples
 
 - For a piece with violin 1 and violin 2:  
   vl  

--- a/default/en/source_595.md
+++ b/default/en/source_595.md
@@ -26,6 +26,6 @@ _Examples_:
 
 Enter the dramatic role that appears on the source if it differs in spelling from the standardized form given above.
 
-_Example_:
+##### Example:
 
 - Pappageno

--- a/default/en/source_596.md
+++ b/default/en/source_596.md
@@ -15,7 +15,7 @@ some have individual numbers while others require page numbers.
 
 Use **Other** for references to printed editions that were not included in the printed volumes of the A/I and B series.
 
-_Example_:
+##### Example:
 
 - Other
 - 1001100380

--- a/default/en/source_597.md
+++ b/default/en/source_597.md
@@ -3,7 +3,7 @@
 #### Colophon (597 $a)
 For printed items, enter the colophon as it appears on the source, typically on the last printed page.
 
-_Example_:
+##### Example:
 
 - Vigilie maiores minoresqz ac vespere mortuorū:ānexis officijs | eorundem expliciunt feliciter. Anno
   dñi.M.cccc.xcij.kł.ij.aprilis

--- a/default/en/source_657.md
+++ b/default/en/source_657.md
@@ -5,7 +5,7 @@ Enter references to the liturgical use of the composition in this field. This in
 celebrations, seasons, days, and other religious holidays. The field is linked to the index **Liturgical festivals**. If
 you need a liturgical festival that isn't yet in the file, please contact the RISM Editorial Center.
 
-_Examples:_
+##### Examples
 
 - Nativitas Domini
 - Mariae (B.V.) Visitatio

--- a/default/en/source_852.md
+++ b/default/en/source_852.md
@@ -12,7 +12,7 @@ Enter the siglum of the holding library. This field is linked to the **Instituti
 
 Enter more specific location information, in particular for large libraries, if not named in the siglum itself. Enter the name of the department in the local language. You may include a translation in square brackets in your cataloging language.
 
-_Examples:_  
+##### Examples  
 - Music Department  
 - Collezioni speciali  
 - Zakład Zbiorów Muzycznych [Music department]
@@ -23,7 +23,7 @@ This field can be used to indicate the name of a special collection, such as a c
 
 Enter in the local language. You may include a translation in square brackets in your cataloging language.
 
-_Example_:  
+##### Example:  
 Sammlung Hanns J. Eller
 
 Note: Enter ownership marks in the field **Provenance note (561)**.
@@ -34,7 +34,7 @@ This field is available in the holdings information for printed music. If your c
 
 Missing parts should be entered in the field **General note (500)**.
 
-_Examples:_  
+##### Examples  
 - vl only  
 - Coro S, A, B only  
 - vol. 1, 3 only  
@@ -46,7 +46,7 @@ _Examples:_
 
 Enter the shelfmark (also called "call number") in this field. Transcribe as precisely as possible, including spacing and punctuation. Enter shelfmarks consistently within any given library collection. Indicate superscript characters with **|** (the vertical pipe). If no shelfmark is present, enter **[without shelfmark]**.The phrase [no indication] can be used if the presence of a shelfmark is unknown. Enter additional shelfmarks in the field **Other shelfmarks (591)**.
 
-_Examples:_  
+##### Examples  
 - Ms Mus 165/6  
 - Mus.ms. 743  
 - Th.mus.A 5  

--- a/default/en/source_856.md
+++ b/default/en/source_856.md
@@ -13,7 +13,7 @@ This field is required when entering a link to an external resource.
 Enter a brief description that explains why the URL is relevant to the source being described. Enter using your
 cataloging language.
 
-_Examples:_
+##### Examples
 
 - Digital copy
 - Watermark on p. 4
@@ -34,12 +34,12 @@ This field is required when entering a link to an external resource. Select from
   The preference is to link to institutional repositories but if one is not available then links to external
   repositories such as the Internet Archive or IMSLP are allowed. For collections, it is not necessary to duplicate the
   same link in the collection main entry and the individual entries.  
-  _Example_:[  
+  ##### Example:[  
   https://mirador.acdh.oeaw.ac.at/musikarchivspitz/A-SPD\_A15/](https://mirador.acdh.oeaw.ac.at/musikarchivspitz/A-SPD_A15/)
 - **IIIF manifest**: The linked object is a machine-readable JSON object processed by an internal document viewer such
   as diva.js. The document is embedded in the web page directly. In many cases, "manifest," "iiif," or similar appears
   in the link.  
-  _Example_:[https://iiif.lib.harvard.edu/manifests/drs:2820650](https://iiif.lib.harvard.edu/manifests/drs:2820650)
+  ##### Example:[https://iiif.lib.harvard.edu/manifests/drs:2820650](https://iiif.lib.harvard.edu/manifests/drs:2820650)
 
 In cases where both links to an external viewer and an IIIF manifest are available, repeat the field and list both links
 separately.

--- a/default/en/work_400.md
+++ b/default/en/work_400.md
@@ -14,7 +14,7 @@ These fields will be identical with the main Heading (100) above.
 Use this field to record title variants, alternatives, nicknames, different spellings, etc. Repeat this field for each
 variation.
 
-_Examples:_
+##### Examples
 - Why fair maid in ev'ry feature
 - Why fair maid in every feature
 - Verrückte Jane

--- a/default/en/work_670.md
+++ b/default/en/work_670.md
@@ -7,7 +7,7 @@ Enter the short title. This field is linked to the **Secondary literature** data
 #### Information found (670 $b)
 Enter the page number and the title of the work as given in the reference source.
 
-_Examples:_
+##### Examples
 - GarveyJacksonW : p. 2-3 (Crazy Jane ("Why fair maid in ev'ry feature") A favorite song...with an accompaniment for the
   harp or piano forte)
 - RitchieW 2008 : p. 110 (A song with lyrics written by Matthew Lewis, composed by Harriett Abrams, entitled "Crazy

--- a/default/es/cat_collections.md
+++ b/default/es/cat_collections.md
@@ -121,7 +121,7 @@ El primer descriptor debe ser **Compilations** (Compilaciones) y/o **Pasticcios*
 **Descripción sumaria (520)**  
 Utilice este campo para describir la naturaleza de la fuente en general.  
 [N. del T.: recuerde que este campo debe estar en inglés]  
-_Ejemplo_:  
+##### Ejemplo:  
 Act 1 by Amadei, act 2 by Bononcini, overture and act 3 by Händel [= Acto 1 de Amadei, acto 2 de Bononcini, obertura y acto 3 de Händel]
 
 **Título alternativo (730)**  
@@ -245,7 +245,7 @@ Existen dos maneras de catalogar periódicos que contienen música: como colecci
 
 Las  **Colecciones ** resultan apropiadas en los casos en los que el periódico consiste en su mayor parte de música y el ítem fue reunido y preservado en su totalidad. Los registros de ejemplar se añaden al nivel de la colección. Se crean entradas individuales para cada pieza de la edición.
 
-_Ejemplo_:  
+##### Ejemplo:  
 1001097294: Edición de enero (año preciso incierto) de la _Kleine Pianoforte-Bibliothek_, que contiene 5 piezas. Hay un registro madre para la colección y cinco entradas individuales, una para cada pieza. 
 
 Las  **Piezas individuales ** pueden resultar apropiadas en los casos en los que las obras fueron incluidas como inserciones o agregados en periódicos sin foco en lo musical. Frecuentemente, este tipo de ítem se conserva por fuera de su contexto de publicación.
@@ -259,7 +259,7 @@ _Ejemplos_:
 
 RISM también incluye música presente en publicaciones impresas que fueron concebidas como documentos fundamentalmente no musicales. El foco de RISM, no obstante, se ubica sobre la música
 
-_Ejemplo_:   
+##### Ejemplo:   
 990026614: 3 canciones de John Isaac Hawkins que fueron incluidas en _Discourse introductory to a course of lectures on the science of nature _(1800), de Charles Willson Peale.  
 **Compositor/Autor (100)**: el compositor de la música.  
 **Nombre personal adicional (700)**: el autor del libro, con la indicación  **other**  

--- a/default/es/institution_034.md
+++ b/default/es/institution_034.md
@@ -4,7 +4,7 @@ Introduzca las coordenadas (latitud y longitud) de la institución en este campo
 
   
 
-_Ejemplos:_
+##### Ejemplos
 
 Longitud: -87.6735541
 

--- a/default/es/institution_110.md
+++ b/default/es/institution_110.md
@@ -14,7 +14,7 @@ En los casos en que las bibliotecas, los archivos o los centros de documentació
 
   
 
-_Ejemplos:_
+##### Ejemplos
 
 Privatsammlung Cees Verheijen
 
@@ -58,7 +58,7 @@ En caso de que una institución haya cambiado de nombre, sigue manteniendo la mi
 
  
 
-_Ejemplos:_
+##### Ejemplos
 
 GB-Cu = Reino Unido, Cambridge, University Library
 

--- a/default/es/institution_368.md
+++ b/default/es/institution_368.md
@@ -28,7 +28,7 @@ Seleccione uno de los siguientes tipos:
 
 Introduzca el tipo de jurisdicción asociada a la institución.
 
-_Ejemplos:_
+##### Ejemplos
 
 Condado
 

--- a/default/es/institution_510.md
+++ b/default/es/institution_510.md
@@ -10,7 +10,7 @@ Registre las diversas formas en que se presenta la forma autorizada del nombre d
 
   
 
-_Ejemplos:_
+##### Ejemplos
 
 The National Library of Wales [for Llyfrgell Genedlaethol Cymru]
 

--- a/default/es/institution_680.md
+++ b/default/es/institution_680.md
@@ -6,7 +6,7 @@ Introduzca notas adicionales que describan la institución, como por ejemplo:
 - Clasificación de la colección: por ejemplo, "Colección en GB-Lbl".  
 - Repositorio en línea: URL del repositorio digital de la institución.  
 - Archivos y otras existencias (ISDIAH 5.3.7): Introduzca los nombres de los fondos y colecciones. Comience cada nombre en una nueva línea. Utilice el nombre tal y como lo utiliza la institución que lo alberga. En el caso de los fondos personales, se recomienda añadir entre paréntesis las fechas de nacimiento y muerte de la persona en cuestión.  Si existen listas o URL con la información sobre las colecciones o fondos de una institución específica, indique la URL.   
-_Ejemplos:_  
+##### Ejemplos  
 Joachim, Joseph (1831-1907) (Royal College of Music, Library)  
 Andrée-Stenhammararkivet  
 Telemann, Georg Michael  

--- a/default/es/publication_020.md
+++ b/default/es/publication_020.md
@@ -2,6 +2,6 @@
 
 Introduzca el Número de Libro Estándar Internacional (ISBN). El ISBN es un número que consta de 10 o 13 dígitos.
 
-_Ejemplos:_  
+##### Ejemplos  
 3-486-21584-1  
 978-3-486-21584-1

--- a/default/es/publication_024.md
+++ b/default/es/publication_024.md
@@ -2,6 +2,6 @@
 
 Registre el Número Estándar Intenacional de Música. El ISMN es un identificador único para la música impresa.
 
-_Examples:_  
+##### Examples  
 979-0-9020000-9-3  
 M-2306-7118-7

--- a/default/es/publication_210.md
+++ b/default/es/publication_210.md
@@ -21,7 +21,7 @@ _Por lo general es el nombre del compositor o el lugar; en otros casos, seleccio
 - **Espacio**
 - **Año de publicación**
 
-_Ejemplos:_
+##### Ejemplos
 
 > Pieter Dirksen, _Heinrich Scheidemann’s Keyboard Music: Transmission, Style and Chronology_ (Aldershot: Ashgate, 2007).  
 >             → DirksenS 2007  
@@ -34,7 +34,7 @@ _Ejemplos:_
 
 En el caso de los autores o editores que publiquen varios artículos sobre el mismo compositor o varias obras del mismo compositor, se añade una letra (**a, b, c,** etc.) al final del año.
 
-_Ejemplos:_
+##### Ejemplos
 
 > Anton Cajetan Adlgasser, _Litaniae de venerabili altaris sacramento in B-Dur (WV 3.53),_ ed. Armin Kircher (Stuttgart: Carus, 2005).  
 >             → KircherA 2005  
@@ -103,7 +103,7 @@ Un catálogo publicado como parte de un ítem mayor, como puede ser el apéndice
 
   
 
-_Ejemplos:_
+##### Ejemplos
 
 > A. Craig Bell, _Handel: Chronological Thematic Catalogue_ (Darley: Grain-Aig Press, 1972).  
 >             → BelH  
@@ -131,7 +131,7 @@ _Ejemplo:_
 
 Las publicaciones que contienen el término _catálogo temático_ en sus títulos suelen ser catálogos de obras, pero también pueden tocar ocasionalmente otros temas o no ser amplias en su alcance. Compruébelo siempre dos veces. Si es el primer caso, asígnele un título breve como si se tratara de un catálogo de obras. Si es el segundo caso, póngale un título breve del mismo modo que para la bibliografía normal. En resumen, a todo lo que no sea un catálogo de obras se le asigna un título breve de bibliografía.
 
-_Ejemplos:_
+##### Ejemplos
 
 > Walter Pass, _Thematischer Katalog sämtlicher Werke Jacob Regnarts (ca. 1540-1599)_ (Vienna: Böhlau, 1969).  
 >             → PasJ  

--- a/default/es/publication_500.md
+++ b/default/es/publication_500.md
@@ -10,7 +10,7 @@ En el caso de tesinas o tesis universitarias, introduzca una nota sobre el lugar
 
   
 
-_Ejemplos:_
+##### Ejemplos
 
 D-Bsa
 

--- a/default/es/publication_502.md
+++ b/default/es/publication_502.md
@@ -2,6 +2,6 @@
 
 Si el ítem es una tesis doctoral, incluya el tipo de grado académico, la institución y el año.
 
-_Ejemplos:_  
+##### Ejemplos  
 Ph.D. diss., University College, London 1998  
 Diss., Freie Universität, Berlin 2002

--- a/default/es/publication_650.md
+++ b/default/es/publication_650.md
@@ -4,7 +4,7 @@ Introduzca un descriptor o una palabra clave que ayude a describir los contenido
 
 Las ubicaciones geográficas se ingresan en el campo **Lugar relacionado (651).**
 
-_Ejemplos:_  
+##### Ejemplos  
 
 Instruments   
 Madrigals   

--- a/default/es/publication_710.md
+++ b/default/es/publication_710.md
@@ -5,6 +5,6 @@ Introduzca el nombre de una institución adicional que esté relacionada con el 
 - **Editor**: Utilícelo especialmente si el autor del ítem es una institución en lugar de una persona.
 - **Otra función**
 
-_Ejemplos:_  
+##### Ejemplos  
 Sing-Akademie zu Berlin   
 Historische Sektion der Bayerischen Benediktinerakademie

--- a/default/es/publication_760.md
+++ b/default/es/publication_760.md
@@ -10,7 +10,7 @@ Escriba el título del periódico, libro o serie. Este campo está vinculado a l
 
 Introduzca, según corresponda, los números de volumen, número, año y/o página del artículo. Por ejemplo, para una publicación periódica, introduzca el volumen, el año y los números de página. Regístrelo de un modo que resulte apropiado al estilo de la revista.
 
-_Ejemplos:_  
+##### Ejemplos  
 23 (1986), p. 5-10  
 2, 35 (2014), 7-16  
 71 (1997), Heft 5, p.275-292  

--- a/default/es/publication_856.md
+++ b/default/es/publication_856.md
@@ -8,7 +8,7 @@ Introduzca una breve nota que describa el enlace.
 
   
 
-_Ejemplos:_
+##### Ejemplos
 
 Recurso electrónico
 

--- a/default/es/source_026.md
+++ b/default/es/source_026.md
@@ -8,7 +8,7 @@ Ingrese el identificador tipográfico completo.
 
 Pueden consultarse de manera online los lineamientos establecidos por el _Institut de Rechercher e d’Histoire des Texte_ y la Biblioteca Nacional de Escocia, tanto en [inglés, francés e italiano](http://edit16.iccu.sbn.it/web_iccu/info/en/Impronta_notiziario.htm), como en [alemán](http://nbn-resolving.de/urn:nbn:de:hbz:6:1-195591).
 
-_Example_:  
+##### Example:  
 n?n, n;t, v.at BeDr C 1695R
 
 Dependiendo del estándar de la descripción pueden utilizarse otros campos disponibles:

--- a/default/es/source_031.md
+++ b/default/es/source_031.md
@@ -26,7 +26,7 @@ Registre el título del movimiento y el tempo –o indicaciones similares–, si
 
 Registre la parte vocal o instrumental correspondiente al íncipit siguiendo la lista de **abreviaturas de instrumentos de RISM**. Use **V** para una parte vocal desconocida e **i** para una parte instrumental desconocida. En el caso de los instrumentos transpositores, transcriba el fragmento en altura real. Indique la afinación del instrumento en el campo **Nota general**.
 
-_Ejemplos:_  
+##### Ejemplos  
 pf  
 T coro  
 org with text

--- a/default/es/source_260.md
+++ b/default/es/source_260.md
@@ -34,7 +34,7 @@ Note que, en el caso de los manuscritos, las fechas se presentan sin corchetes, 
 
 Se pueden indicar otras fechas que aparecen en la fuente. Utilice signos de interrogación para señalar información que resulte incierta.
 
-_Ejemplos:_  
+##### Ejemplos  
 1875  
  1875 Día de Navidad  
  1757-01-11  

--- a/default/es/source_300.md
+++ b/default/es/source_300.md
@@ -50,7 +50,7 @@ También se pueden indicar páginas o folios particulares de una pieza dentro de
 
 No consigne la extensión de las particellas aquí. Para ello utilice el campo **Particellas conservadas (590).**
 
-_Ejemplos:_  
+##### Ejemplos  
 1 _score_: 35 p.  
 1 _score_ (2x): 2, 2 f.  
 1 _short score_: 8 f.  

--- a/default/es/source_520.md
+++ b/default/es/source_520.md
@@ -4,7 +4,7 @@ En este campo se puede registrar, de manera breve, información general sobre la
 
 En caso de que desee aportar información más detallada sobre los contenidos de la fuente, puede hacerlo en el campo **Nota sobre el contenido (505)**.
 
-_Ejemplos:_  
+##### Ejemplos  
 5 sonatas, 2 fantasies  
 5 motets, 2 masses, 1 Magnificat   
 Opera in 3 acts   

--- a/default/es/source_588.md
+++ b/default/es/source_588.md
@@ -8,7 +8,7 @@ Introduzca la sigla del repostorio y la signatura topográfica de la edición im
 
   
 
-_Ejemplos:_
+##### Ejemplos
 
 - CZ-Nlob X A a 12
 - (incipits:) US-BETm LCM 242

--- a/default/es/source_594.md
+++ b/default/es/source_594.md
@@ -57,7 +57,7 @@ org
 
 Indique aquí el número total de partes. Si una pieza incluye dos partes del mismo instrumento, consigne el instrumento solamente en campo **Voz/instrumento** e indique **2** en el campo **Número**.
 
-_Ejemplos:_
+##### Ejemplos
 
 - Para una pieza con violín 1 y violín 2:  
 vl  

--- a/default/es/source_597.md
+++ b/default/es/source_597.md
@@ -2,5 +2,5 @@
 
 En el caso de los ítems impresos, registre el colofón tal como se presenta en la fuente (de manera típica, en la última página impresa).
 
-_Ejemplo_:  
+##### Ejemplo:  
 Vigilie maiores minoresqz ac vespere mortuorū:ānexis officijs | eorundem expliciunt feliciter. Anno dñi.M.cccc.xcij.kł.ij.aprilis

--- a/default/es/source_657.md
+++ b/default/es/source_657.md
@@ -2,7 +2,7 @@
 
 Registre referencias al uso litúrgico de la composición en este campo. Esto incluye festividades, celebraciones, tiempos del año litúrgico, días y otras fiestas religiosas. El campo está vinculado al índice de autoridades de **Festividades litúrgicas**. Si necesita consignar una festividad litúrgica que aún no está en el archivo de autoridades, por favor contáctese con la Oficina Central de RISM.
 
-_Ejemplos:_  
+##### Ejemplos  
 Nativitas Domini  
 Mariae (B.V.) Visitatio  
 Single Sisters Covenant Day (Iglesia Moravia)

--- a/default/es/source_730.md
+++ b/default/es/source_730.md
@@ -48,7 +48,7 @@ Título uniforme_: Consola amato bene_
 Título uniforme: _Una cosa rara_ [más  **Inserciones** en el campo**Tipo especial de fuente (730 $k)**]
 
 Este campo también puede utilizarse para títulos de periódicos o series.  
-_Ejemplos:_  
+##### Ejemplos  
 _Oeuvres Complets de Piano_  
 _Molenaar's Muziekuitgaven voor Harmonie- en Fanfare-orkesten_  
 _Nouveau Mercure galant, mai 1679_  

--- a/default/es/source_852.md
+++ b/default/es/source_852.md
@@ -23,7 +23,7 @@ Este campo puede usarse para registrar el nombre de una colección especial, com
 
 Complete el campo con el idioma local. Puede incluir una traducción a su idioma de catalogación entre corchetes.
 
-_Ejemplo_:  
+##### Ejemplo:  
 Sammlung Hanns J. Eller
 
 Nota: señale las marcas del propietario en el campo **Nota de procedencia (561)**.
@@ -46,7 +46,7 @@ complete
 
 Ingrese la signatura topográfica (llamada también “número de clasificación”) en este campo. Transcríbala tan precisamente como sea posible, incluyendo los espacios y la puntuación. Ingrese las signaturas de un modo consistente dentro de una misma colección de un repositorio dado. Indique caracteres en superíndice con | (barra vertical). Si no cuenta con una signatura presente, ingrese **[without shelfmark]** (sin signatura, en inglés). Registre signaturas adicionales en el campo **Otras signaturas (591).**
 
-_Ejemplos:_  
+##### Ejemplos  
 Ms Mus 165/6  
 Mus.ms. 743  
 Th.mus.A 5  

--- a/default/es/source_856.md
+++ b/default/es/source_856.md
@@ -31,7 +31,7 @@ _Ejemplo:
 [https://mirador.acdh.oeaw.ac.at/musikarchivspitz/A-SPD\_A15/](https://mirador.acdh.oeaw.ac.at/musikarchivspitz/A-SPD_A15/)_  
 
 - **Manifiesto IIIF**: el objeto vinculado es un objeto JSON legible por máquina, procesado con un visor de documentos interno como diva.js. El documento aparece incrustado directamente en la página web. En muchos casos, el link mismo incluye partículas como "manifest," "iiif" u otras similares.  
-_Ejemplo_:   
+##### Ejemplo:   
 *[https://iiif.lib.harvard.edu/manifests/drs:2820650](https://iiif.lib.harvard.edu/manifests/drs:2820650)*  
   
 En casos en los que haya enlaces disponibles tanto a un visor externo como a un manifiesto IIIF, repita el campo y consigne ambos enlaces por separado.  

--- a/default/es/work_400.md
+++ b/default/es/work_400.md
@@ -14,7 +14,7 @@ Estos campos serán idénticos al Encabezado (100) principal que se encuentra ar
 #### Título de la obra (400 $t)
 Utilice este campo para registrar variantes del título, alternativas, sobrenombres, diferentes ortografías, etc. Repita este campo para cada variación.
 
-_Ejemplos:_  
+##### Ejemplos  
 Why fair maid in ev'ry feature  
 Why fair maid in every feature  
 Verrückte Jane  

--- a/default/it/institution_680.md
+++ b/default/it/institution_680.md
@@ -6,7 +6,7 @@ Inserisci note aggiuntive che descrivono l’istituzione, come ad esempio:
 - Classificazione della collezione, come “Collection in GB-Lbl”.  
 - Deposito online: URL del deposito digitale dell’istituzione.
 - Collezioni archivistiche e non-archivistiche (ISDIAH 5.3.7): Inserisci i nomi dei fondi e delle collezioni. Inizia ogni nome su una nuova riga. Utilizza il nome come è usato dall’istituzione proprietaria. In caso di fondi personali, è consigliabile aggiungere tra parentesi le date di nascita e di morte della persona in questione. Se ci sono elenchi o URL con informazioni sulle collezioni o sui fondi di una particolare istituzione, fornisci lo URL.  
-_Esempi:_  
+##### Esempi  
  Joachim, Joseph (1831-1907) (Royal College of Music, Library)  
  Andrée-Stenhammararkivet  
  Telemann, Georg Michael  

--- a/default/it/publication_022.md
+++ b/default/it/publication_022.md
@@ -2,7 +2,7 @@ ISSN (022 $a)
 
  Inserisci il numero International Standard Serial Number (ISSN). Il numero ISSN è un identificatore univoco per pubblicazioni periodiche.  
 
-_Esempi:_  
+##### Esempi  
 0027-4380  
 0003-0139  
 1068-2724 

--- a/default/it/publication_024.md
+++ b/default/it/publication_024.md
@@ -2,6 +2,6 @@ ISMN (024 $a)
 
  Inserisci il numero International Standard Music Number (ISMN). Il numero ISMN è un identificatore univoco per edizioni musicali.  
   
-_Esempi:_  
+##### Esempi  
 979-0-9020000-9-3  
 M-2306-7118-7 

--- a/default/it/publication_210.md
+++ b/default/it/publication_210.md
@@ -16,7 +16,7 @@ _Solitamente il nome del compositore o il luogo, altrimenti seleziona un'altra p
 - **Spazio**
 - **Anno** di pubblicazione
 
-_Esempi:_
+##### Esempi
 
 > Pieter Dirksen, _Heinrich Scheidemann’s Keyboard Music: Transmission, Style and Chronology_ (Aldershot: Ashgate, 2007).  
 >             → DirksenS 2007  
@@ -30,7 +30,7 @@ _Esempi:_
   
 Per autori o curatori che pubblicano più articoli sullo stesso compositore o più opere dello stesso compositore, si aggiunge una lettera (**a**, **b**, **c** ecc.) dopo l'anno.  
   
-_Esempi:_  
+##### Esempi  
   
 
 > Anton Cajetan Adlgasser, _Litaniae de venerabili altaris sacramento in B-Dur (WV 3.53),_ ed. Armin Kircher (Stuttgart: Carus, 2005).  
@@ -96,7 +96,7 @@ Non è necessario indicare l'anno.
 
 Un catalogo pubblicato come parte di un'opera di più ampio respiro, come un'appendice in un libro, può essere inserito come un catalogo di opere. Simili oggetti possono anche essere citati fra i  **Riferimenti bibliografici**  **(691****)**. 
 
-_Esempi:_
+##### Esempi
 
 > A. Craig Bell, _Handel: Chronological Thematic Catalogue_ (Darley: Grain-Aig Press, 1972).  
 >             → BelH  
@@ -109,7 +109,7 @@ _Esempi:_
 
 Utilizza le abbreviazioni correnti, se esistono (BWV, KV, Hob. ecc.). Puoi anche usare l'abbreviazione usata nel catalogo stesso se non porta a confusione.    
   
-_Esempi:_  
+##### Esempi  
 
 > Horst Augsbach, Quantz-Werkverzeichnis (Stuttgart: Carus, 1997).  
 >            → QV  
@@ -127,7 +127,7 @@ _Esempi:_
 
 Pubblicazioni che contengono il termine _catalogo tematico_ nel titolo spesso sono cataloghi di opere, ma a volte riguardano anche altri argomenti o non sono esaustive. Controlla ogni volta. Se si tratta del primo caso, assegna un'abbreviazione di catalogo di opere. Nel secondo caso, assegna un'abbreviazione come per la normale bibliografia. Insomma, qualsiasi cosa che non sia un catalogo di opere riceve un'abbreviazione come la bibliografia di riferimento. 
 
-_Esempi:_
+##### Esempi
 
 > Walter Pass, _Thematischer Katalog sämtlicher Werke Jacob Regnarts (ca. 1540-1599)_ (Vienna: Böhlau, 1969).  
 >             → PasJ  

--- a/default/it/publication_502.md
+++ b/default/it/publication_502.md
@@ -2,6 +2,6 @@
 
 Se l'oggetto è una dissertazione di dottorato, includi il tipo di dottorato, l'istituzione e l'anno. 
 
-_Esempi:_  
+##### Esempi  
 Ph.D. diss., University College, London 1998  
 Diss., Freie Universität, Berlin 2002 

--- a/default/it/publication_520.md
+++ b/default/it/publication_520.md
@@ -2,6 +2,6 @@
 
 Questo campo riporta le date di inizio e fine relative a un oggetto, specialmente per i periodici.  
   
-_Esempi:_  
+##### Esempi  
 Vol. 1, no. 1 (Apr. 1981)-  
 1969-2004

--- a/default/it/publication_650.md
+++ b/default/it/publication_650.md
@@ -4,7 +4,7 @@ Inserisci un soggetto o una parola chiave che aiuti a descrivere il contenuto de
   
 Luoghi geografici sono inseriti nel campo **Luogo****  correlato (651)**.  
   
-_Esempi:_  
+##### Esempi  
 Instruments   
 Madrigals   
 Schriftsteller   

--- a/default/it/publication_710.md
+++ b/default/it/publication_710.md
@@ -5,6 +5,6 @@ Inserisci il nome di un’istituzione aggiuntiva correlata all’oggetto. Non ri
 
 - **Editor**: curatore: utilizza in particolare se l’oggetto ha come autore un’istituzione piuttosto che una persona.
 - **Other function**: altra funzione
-_Esempi:_  
+##### Esempi  
 Sing-Akademie zu Berlin   
 Historische Sektion der Bayerischen Benediktinerakademie

--- a/default/it/publication_856.md
+++ b/default/it/publication_856.md
@@ -8,7 +8,7 @@ Inserisci lo URL della risorsa esterna. Utilizza ovunque possibile dei collegame
 
 Inserisci una breve nota che descrive il collegamento.  
   
-_Esempi:_  
+##### Esempi  
 Electronic resource  
 Elektronische Ressource  
 Link to PDF  

--- a/default/it/source_031.md
+++ b/default/it/source_031.md
@@ -77,7 +77,7 @@ Seleziona la tonalità o il modo dalla lista.
 
 Inserisci **x** per tonalità diesizzate o **b** per tonalità bemollizzate. Inserisci poi i nomi delle note che sono influenzate dall’armatura di chiave. Aggiungi diesis o bemolli palesemente mancanti tra parentesi quadre. Se manca l’armatura di chiave, lascia il campo vuoto.
 
-_Esempi:_  
+##### Esempi  
 xF = il fa è diesizzato = sol maggiore o re minore  
 bBE = il si e il mi sono bemollizzati = si bemolle maggiore o sol minore  
 xFC[G] = il fa e il do sono diesizzati ma il brano è palesemente in la maggiore, dunque l'ultimo diesis è aggiunto tra parentesi quadre
@@ -194,7 +194,7 @@ Esempio:
    
 La durata totale del gruppo deve essere scritta prima della **(**. Il valore ritmico della prima nota deve essere indicata dopo la **(**, anche se è identica alla nota immediatamente precedente la sezione nel ritmo speciale. Il numero di note nel gruppo deve essere indicato prima di **)**. È separato dall’ultima nota da **;**.
 
-_Esempi:_  
+##### Esempi  
 8(3ABCDE;5) = quintina, cinque trentaduesimi/biscrome nello spazio di un ottavo/una croma.  
 8({3ABCDE};5) = quintina, cinque trentaduesimi/biscrome nello spazio di un ottavo/una croma, con travatura  
 
@@ -239,7 +239,7 @@ La sequenza ritmica si interrompe non appena compare un nuovo valore ritmico.
 
 Utilizza % per cambiare la chiave, $ per cambiare la tonalità e @ per cambiare la misura. Fai seguire questi segni con la nuova indicazione generale (chiave, tonalità o misura) seguita da uno spazio.
 
-_Esempi:_  
+##### Esempi  
 %C-1 '2A  
 %C-1 $xFC '8B  
 @3/2 '1C  
@@ -272,6 +272,6 @@ Aggiungi commenti come l’accordatura degli strumenti traspositori, errori nell
 
 In questo campo puoi indicare l’organico specifico del movimento in questione (come un movimento all’interno di una complessa composizione vocale). Elenca l’organico su una linea utilizzando le abbreviazioni RISM per gli strumenti e l’ordine standardizzato (descritto in **Organico sintetico** **[240 $m]**). Usa un punto e virgola per separare famiglie di strumenti. 
 
-_Esempi:_   
+##### Esempi   
 S (Enrico), T (Vanoldo); vl 1, 2, b; [winds]  
 S 2 solo; Coro; ob obl; strings, bc

--- a/default/it/source_240.md
+++ b/default/it/source_240.md
@@ -20,7 +20,7 @@ Inserisci il titolo proprio con un’ortografia standardizzata secondo (1) New G
   
 Nomi popolari o nomignoli (come “Eroica” o “messa di Nelson”) non sono considerati titoli propri. Tali nomi si inserscono nel campo **Titolo uniforme alternativo (730 $a)**.   
   
-_Esempi:_  
+##### Esempi  
 Die Forelle  
  Die Zauberflöte  
  The beggar's opera  
@@ -38,14 +38,14 @@ Inserendo un incipit testuale, utilizza le regole ortografiche della lingua risp
   
 Assicurati che l’incipit testuale in questo campo sia identico con l’incipit testuale nel campo **Incipit testuale (031 $t)**. In caso di testi latini, utilizza il testo che precede la virgola (nella lista in appendice) come titolo uniforme ma utilizza l’intero incipit testuale come incipit testuale.   
   
-_Esempi:_  
+##### Esempi  
 Der Mond ist aufgegangen  
  Gloria [con l’incipit testuale: Gloria, in excelsis Deo et in terra pax]  
   
 3. **Generi musicali**  
 Utilizza il genere del brano come titolo uniforme se non vi è né un titolo proprio né un incipit testuale. Nella maggior parte dei casi, inserisci il genere in inglese e al plurale (ad esempio **Operas**). Nota che con alcuni generi si utilizza un particolare **Soggetto (650)**. Si consulti l’appendice **Titoli uniformi – Soggetti** nelle **Regole di catalogazione** per ulteriori istruzioni.   
   
-_Esempi:_  
+##### Esempi  
 Symphonies  
  Allemandes  
   
@@ -55,7 +55,7 @@ Inserisci l’indicazione di tempo se non è possibile determinare il genere. Se
  -Pieces (un brano generico)  
  -Movements (un singolo movimento di un pezzo strumentale senza indicazione di tempo e di carattere indeterminato)  
   
-_Esempi:_  
+##### Esempi  
 Presto  
  Lento
 
@@ -63,7 +63,7 @@ Presto
 
 - **Raccolte.**  In questi casi si inserisce un numero e il genere. Inserisci una cifra araba che indica quante composizioni si trovano nella raccolta, seguita da un genere che comprenda quante più composizioni possibile.
 
-> _Esempi:_  
+> ##### Esempi  
 > 3 Instrumental pieces  
 > 25 Arias
 

--- a/default/it/source_260.md
+++ b/default/it/source_260.md
@@ -38,7 +38,7 @@ Nota che la datazione di un manoscritto è indicata senza parentesi quadre perch
 
 Altre date possono essere indicate come si presentano sulla fonte. Usa un punto interrogativo per indicare l’incertezza delle informazioni.
 
-_Esempi:_  
+##### Esempi  
 1875  
 1856 Christmas Day  
 1757-01-11  

--- a/default/it/source_506.md
+++ b/default/it/source_506.md
@@ -2,6 +2,6 @@
 
 Puoi inserire qui le condizioni dell’istituzione proprietaria della fonte. Inserisci i dati usando la tua lingua di catalogazione. 
 
-_Esempi:_  
+##### Esempi  
 Consultazione nella sala di lettura.  
 Riproduzioni su richiesta (secondo i casi a pagamento).

--- a/default/it/source_588.md
+++ b/default/it/source_588.md
@@ -4,7 +4,7 @@ Questo campo specifica la copia fisica consultata per catalogare un'edizione mus
 
 Inserisci la sigla della biblioteca e la collocazione dell’edizione a stampa consultata. Puoi anche indicare se hai utilizzato una specifica copia soltanto per una parte della scheda, ad esempio per gli incipit o per le schede individuali.
 
-_Esempi:_
+##### Esempi
 
 - CZ-Nlob X A a 12
 - (incipits:) US-BETm LCM 242

--- a/default/it/source_594.md
+++ b/default/it/source_594.md
@@ -32,7 +32,7 @@ Elenca l’organico nell’ordine seguente:
 
 Elenca le parti dall’ambito più acuto all’ambito più grave. Inserisci uno strumento per riga. Aggiungi tra parentesi delle possibilità di organico alternative.
 
-_Esempi:_
+##### Esempi
 
 S 1  
 S 2  
@@ -58,7 +58,7 @@ org
 
 Indica qui il numero totale di parti. Se un brano include due parti per lo stesso strumento, indica lo strumento individuale nel campo **Organico** e **2** nel campo **Numero**.
 
-_Esempi:_  
+##### Esempi  
 vl         2 [per un brano con violino 1 e violino 2]  
 vla       1 [solo 1 parte di viola]  
 ob        2 [oboe 1 e oboe 2]  

--- a/default/it/source_657.md
+++ b/default/it/source_657.md
@@ -2,7 +2,7 @@
 
 Inserisci in questo campo il riferimento all’uso liturgico della composizione. Questo comprende feste liturgiche, festività, celebrazioni, stagioni, giornate e altre feste religiose. Il campo è collegato all’indice **Feste liturgiche**. Se cerchi una festa liturgica che non è ancora presente nell’indice, rivolgiti per favore al RISM Editorial Center. 
 
-_Esempi:_  
+##### Esempi  
 Nativitas Domini  
 Mariae (B.V.) Visitatio  
 Single Sisters Covenant Day (Moravian Church)

--- a/default/it/source_852.md
+++ b/default/it/source_852.md
@@ -35,7 +35,7 @@ Questo campo è disponibile nelle informazioni di possesso per edizioni musicali
 
 Parti mancanti vanno indicate nel campo  **Nota generale** **(500)**.
 
-_Esempi:_  
+##### Esempi  
 vl only  
 Coro S, A, B only  
 vol. 1, 3 only  
@@ -47,7 +47,7 @@ complete
 
 Inserisci la segnatura (o collocazione) in questo campo. Trascrivi quanto più precisamente possibile, comprese spaziatura e punteggiatura. Inserisci le segnature coerentemente all’interno di uno stesso fondo bibliotecario. Indica caratteri in apice con **|** (la barretta verticale). Se non è presente alcuna segnatura, inserisci **[without shelfmark]**. Inserisci segnature aggiuntive nel campo **Altra segnatura (591)**.
 
-_Esempi:_  
+##### Esempi  
 Ms Mus 165/6  
 Mus.ms. 743  
 Th.mus.A 5  

--- a/default/it/source_856.md
+++ b/default/it/source_856.md
@@ -15,7 +15,7 @@ Questo campo è obbligatorio se si inserisce un collegamento internet.
 
 Inserisci una breve nota spiegando perché il collegamento è rilevante per la fonte descritta. Inserisci utilizzando la tua lingua di catalogazione.
 
-_Esempi:_  
+##### Esempi  
 Copia digitale  
 Filigrana a p. 4  
 Homepage del progetto  

--- a/default/it/work_400.md
+++ b/default/it/work_400.md
@@ -13,7 +13,7 @@ Riempi i campi come sopra nell'intestazione principale (100).
 #### Titolo dell'opera (400 $t)
 Usa questo campo per riportare varianti del titolo, titoli alternativi, nomi popolari, ortografie aggiuntive, ecc. Ripeti il campo per ciascuna variante.
 
-_Esempi:_  
+##### Esempi  
 Why fair maid in ev'ry feature  
 Why fair maid in every feature  
 Verrückte Jane  

--- a/default/it/work_670.md
+++ b/default/it/work_670.md
@@ -7,6 +7,6 @@ Inserisci il titolo abbreviato del riferimento bibliografico. Il campo è colleg
 #### Riferimento dell'informazione (670 $b)
 Inserisci il numero di pagina e il titolo dell'opera come compaiono nella bibliografia di riferimento.
 
-_Esempi:_  
+##### Esempi  
 GarveyJacksonW : p. 2-3 (Crazy Jane ("Why fair maid in ev'ry feature") A favorite song...with an accompaniment for the harp or piano forte)  
 RitchieW 2008 : p. 110 (A song with lyrics written by Matthew Lewis, composed by Harriett Abrams, entitled "Crazy Jane" (c.1799))

--- a/default/pl/cat_collections.md
+++ b/default/pl/cat_collections.md
@@ -89,7 +89,7 @@ _1001097294:_ Styczniowy numer (dokładny rok nie jest określony) _Kleine Piano
   
 **Pojedyncze dzieła**: kiedy źródło muzyczne stanowi wkładkę lub dodatek do periodyku.   
 Często takie źródła zachowane są w oderwaniu od oryginalnego kontekstu publikacji.      
-_Przykłady:_  
+##### Przykłady  
 991018149: „The Pantheon” opublikowane w The Lady's Magazine, sierpień 1784
 
 990042111: „L'amour folâtrant l'autre jour” opublikowane w Nouveau Mercure galant, maj 1679  

--- a/default/pl/cat_printed.md
+++ b/default/pl/cat_printed.md
@@ -120,7 +120,7 @@ Tytuł ujednolicony: Musikalische Grabschrift
 2. **Uzyskiwanie tytułu ujednoliconego z tytuły charakterystycznego**  
 Tytuły ujednolicone winny składać się tytułu druku aż do miejsca naturalnej przerwy, często przecinka, kropki lub oznaczenia autora, instrumentacji, numeru lub stopki wydawniczej. Czasami charakterystyczny tytuł znajduje się na innej stronie niż strona tytułowa.  
 
-_Przykłady:_  
+##### Przykłady  
 
 RISM A/I: B 805  
 Tytuł widniejący na źródle: Vezzo di perle musicali modernamente conteste alla regia sposa effigiata nella sacra cantica; opera ventesima terza  

--- a/default/pl/institution_368.md
+++ b/default/pl/institution_368.md
@@ -22,7 +22,7 @@ Należy wybrać spośród następujących :
 - Inne
 **Typ jednostki geograficznej (368 $b)**  
 Wprowadź typ jednostki geograficznej związanej z instytucją.  
-_Przykłady:_  
+##### Przykłady  
 hrabstwo  
 wieś  
   

--- a/default/pl/institution_680.md
+++ b/default/pl/institution_680.md
@@ -6,7 +6,7 @@ Wprowadzić dodatkowe uwagi opisujące daną instytucję, takie jak:
 - Klasyfikacja kolekcji, np. „Kolekcja w GB-Lbl”
 - Repozytorium online: URL repozytorium cyfrowego instytucji.  
 - Zbiory archiwalne i inne (ISDIAH 5.3.7): Wprowadzić nazwy zespołów archiwalnych i  kolekcji. Każdą nazwę należy rozpoczynać od nowego wiersza. Użyć nazwy używanej przez instytucję przechowującą. W przypadku zespołów osobowych, zaleca się dodanie w nawiasie dat urodzenia i śmierci danej osoby.  Jeśli istnieją listy lub adresy URL z informacjami o zbiorach lub zespołach archiwalnych danej instytucji, należy podać adres URL.   
-_Przykłady:_  
+##### Przykłady  
   Joachim, Joseph (1831-1907) (Royal College of Music, Library)  
   Andrée-Stenhammararkivet  
   Telemann, Georg Michael  

--- a/default/pl/publication_020.md
+++ b/default/pl/publication_020.md
@@ -2,6 +2,6 @@
 
 Wprowadzić numer ISBN. Numer ISBN jest numerem składającym się z 10-13 cyfr.
 
-_Przykłady:_  
+##### Przykłady  
 3-486-21584-1  
 978-3-486-21584-1

--- a/default/pl/publication_022.md
+++ b/default/pl/publication_022.md
@@ -1,6 +1,6 @@
 **#### ISSN (022 $a)**Wprowadzić numer ISSN. Numer ISSN stanowi unikalny identyfikator wydawnictw ciągłych.
 
-_Przykłady:_  
+##### Przykłady  
 0027-4380  
 0003-0139  
 1068-2724

--- a/default/pl/publication_024.md
+++ b/default/pl/publication_024.md
@@ -2,6 +2,6 @@
 
 Wprowadzić numer ISMN. Numer ISMN stanowi unikalny identyfikator nut drukowanych.   
   
-_Przykłady:_  
+##### Przykłady  
 979-0-9020000-9-3  
 M-2306-7118-7

--- a/default/pl/publication_210.md
+++ b/default/pl/publication_210.md
@@ -18,7 +18,7 @@ _Zazwyczaj imię kompozytora lub nazwa miejsca, w przeciwnym razie należy wybra
 - **Spację**
 - **Rok** wydania
 
-_Przykłady:_
+##### Przykłady
 
 > Pieter Dirksen, _Heinrich Scheidemann’s Keyboard Music: Transmission, Style and Chronology_ (Aldershot: Ashgate, 2007).  
 >             → DirksenS 2007  
@@ -33,7 +33,7 @@ W przypadku autorów lub redaktorów, którzy opublikowali wiele artykułów na 
 
   
 
-_Przykłady:_
+##### Przykłady
 
 > Anton Cajetan Adlgasser, _Litaniae de venerabili altaris sacramento in B-Dur (WV 3.53),_ ed. Armin Kircher (Stuttgart: Carus, 2005).  
 >             → KircherA 2005  
@@ -99,7 +99,7 @@ Nie ma potrzeby podawania roku wydania.
   
 Jako katalog utworów można również wprowadzić  katalog wydany jako część większej pozycji, np. jako aneks do książki, Pozycje takie można również cytować jako  **Odniesienie bibliograficzne****  (691)**.]
 
-_Przykłady:_
+##### Przykłady
 
 > A. Craig Bell, _Handel: Chronological Thematic Catalogue_ (Darley: Grain-Aig Press, 1972).  
 >             → BelH  
@@ -130,7 +130,7 @@ _Przykład:_
 
 Publikacje zawierające w swych tytułach termin _katalog tematyczny_ mogą niekiedy dotyczyć też innej tematyki lub mieć niezbyt rozległy zakres. Zawsze należy to ustalić. W pierwszym przypadku należy nadać tytuł skrócony jak w przypadku katalogu dzieł. W drugim, należy nadać tytuł skrócony nadawany w przypadku literatury normalnej. W skrócie mówiąc: Wszystkiemu, co nie jest katalogiem dzieł, przypisuje się tytuł skrócony stosowany w przypadku literatury.
 
-_Przykłady:_
+##### Przykłady
 
 > Walter Pass, _Thematischer Katalog sämtlicher Werke Jacob Regnarts (ca. 1540-1599)_ (Vienna: Böhlau, 1969).  
 >             → PasJ  

--- a/default/pl/publication_300.md
+++ b/default/pl/publication_300.md
@@ -3,7 +3,7 @@
 
 Wprowadzić objętość danego obiektu, podając liczbę stron lub tomów.  
   
-_Przykłady:_  
+##### Przykłady  
 270 str.  
 xxi, 528 str.  
 2 vol.: XI, 518 str.; 480 str.

--- a/default/pl/publication_502.md
+++ b/default/pl/publication_502.md
@@ -2,6 +2,6 @@
 
 Jeżeli dana pozycja jest pracą doktorską, należy podać typ stopnia naukowego, instytucję i rok.
 
-_Przykłady:_  
+##### Przykłady  
 Ph.D. diss., University College, London 1998  
 Diss., Freie Universität, Berlin 2002

--- a/default/pl/publication_650.md
+++ b/default/pl/publication_650.md
@@ -5,7 +5,7 @@ Podać hasło przedmiotowe lub słowo kluczowe, które pomoże opisać zawartoś
 
 Nazwy geograficzne wprowadza się w polu **Powiązane miejsce (651)**.
 
-_Przykłady:_  
+##### Przykłady  
 Instruments  
 Madrygały  
 Schriftsteller   

--- a/default/pl/publication_710.md
+++ b/default/pl/publication_710.md
@@ -7,6 +7,6 @@ Korzystać tylko z dwóch funkcji:
 - **Edytor**: Stosować szczególnie, gdy jako autora pozycji podano raczej instytucję niż osoby.
 - **Inna funkcja**  
 
-_Przykłady:_  
+##### Przykłady  
 Sing-Akademie zu Berlin   
 Historische Sektion der Bayerischen Benediktinerakademie

--- a/default/pl/publication_856.md
+++ b/default/pl/publication_856.md
@@ -7,7 +7,7 @@ Wprowadzić URL źródła zewnętrznego. Zawsze należy starać się używać pe
 
 Wprowadzić krótką uwagę opisującą link.
 
-_Przykłady:_  
+##### Przykłady  
 Zasób elektroniczny  
 Elektronische Ressource  
 Link do PDF  

--- a/default/pl/source_028.md
+++ b/default/pl/source_028.md
@@ -4,7 +4,7 @@ Pole służy do wprowadzania numerów wydawniczych, które na ogół znajdują s
 
 Wprowadzić numer wydawniczy dokładnie w takiej formie, w jakiej występuje on w źródle.
 
-_Przykłady:_
+##### Przykłady
 
 XLII [42]  
 B. & H. 8533  

--- a/default/pl/source_031.md
+++ b/default/pl/source_031.md
@@ -77,7 +77,7 @@ Należy wybrać tonację lub modus z listy.
 
 Wprowadzić **x** dla tonacji durowych lub **b** dla tonacji molowych, podając następnie wielkie litery dźwięków, które mają być podniesione lub obniżone. Jeżeli dany utwór jest wyraźnie napisany w danej tonacji, lecz w znakach przykluczowych nie podano krzyżyka lub bemolu, brakujące krzyżyki i bemole można dodać w nawiasach. W przypadku braku znaków przykluczowych, należy pozostawić puste miejsce.
 
-_Przykłady:_  
+##### Przykłady  
 xF = F jest dur = G dur lub E moll  
 bBE = B i E są moll = B-dur/B-flat major lub G moll  
 xFC[G] = F and C są w źródle dur, ale utwór jest wyraźnie napisany w tonacji A dur, więc ostatni krzyżyk dodano w nawiasach.
@@ -203,7 +203,7 @@ Przykład:
    
 Ogólną wartość trwania grupy należy podać przed **(**. Wartość rytmiczna pierwszej nuty należy podać po **(**, nawet jeśli jest identyczna jak wartość nuty znajdującej tuż przed sekcją specjalnego rytmu. Liczbę nut w grupie należy wskazać przed ). Należy ją oddzielić od ostatniej nuty za pomocą ;.
 
-_Przykłady:_  
+##### Przykłady  
 8(3ABCDE;5)  = grupa pięciu trzydziestodwójek w miejsce jednej ósemki.  
 
 8({3ABCDE};5) = grupa pięciu trzydziestodwójek w miejsce jednej ósemki, belkowana.
@@ -251,7 +251,7 @@ Sekwencja rytmiczna kończy się w momencie, gdy pojawia się inna wartość ryt
 
 Należy stosować znak **%** by zmienić klucz, **$** by zmienić tonację, oraz **@** by zmienić znaki metrum. Następnie należy wpisać nowe oznaczenie (klucz, tonacja lub metrum), a następnie spację.
 
-_Przykłady:_  
+##### Przykłady  
 %C-1 '2A  
 %C-1 $xFC '8B  
 @3/2 '1C  
@@ -263,7 +263,7 @@ $nBE $xFC
 
 Skrócone formy notacji występujące w nutach, takie jak tremola lub znaki simile, należy wpisać w całości stosując występującą w źródle notację.
 
-_Przykłady:_  
+##### Przykłady  
 {'8DDDD} = półnuta/minima/półtremolo na D
 
  
@@ -289,6 +289,6 @@ Tu należy wprowadzić wszelkie inne uwagi, takie jak wysokość dźwięku trans
 
 W tym polu należy podać konkretną obsadę danej części (takiej, jak np. część w obrębie skomplikowanego utworu wokalnego). Obsadę należy podać w jednej linii stosując skróty instrumentów RISM i standardową kolejność (opisaną w Podsumowaniu ** obsady** **[240 $m]**). Do oddzielenia rodzin instrumentów należy należy stosować znak średnika.
 
-_Przykłady:_   
+##### Przykłady   
 S (Enrico), T (Vanoldo); vl 1, 2, b; [winds]  
 S 2 solo; Coro; ob obl; strings, bc

--- a/default/pl/source_240.md
+++ b/default/pl/source_240.md
@@ -26,7 +26,7 @@ Wpisać uznany tytuł stosując standardową pisownię wg (1) New Grove, (2) MGG
   
 Popularne nazwy lub pseudonimy (takie jak „Eroica” czy „Msza Nelsońska”) nie liczą się jako tytuły ujednolicone. Takie nazwy wpisuje się w pole **Dodatkowe tytuły (730 $a)**.  
   
-_Przykłady:_  
+##### Przykłady  
 Die Forelle  
  Die Zauberflöte  
  The beggar's opera  
@@ -45,14 +45,14 @@ Przy wprowadzaniu incipitów tekstowych, należy stosować zasady ortografii ka�
   
 Należy się upewnić, czy incipit tekstowy w tym polu jest tożsamy z polem tekstowym w polu Incipit tekstowy (031 $t). W przypadku tekstów łacińskich należy stosować tekst poprzedzający przecinek (z listy w aneksie) jako tytuł ujednolicony w całej swojej postaci.  
   
-_Przykłady:_  
+##### Przykłady  
 Der Mond ist aufgegangen  
  Gloria [z incipitem tekstowym: Gloria, in excelsis Deo et in terra pax]  
   
 3. **Gatunek**  
 Użyć gatunku utworu jako tytułu ujednoliconego, w razie braku odrębnego tytułu lub incipitu tekstowego. W większości przypadków należy wpisać gatunek w języku angielskim i w liczbie mnogiej (np. **Operas**). Należy przy tym pamiętać, że w przypadku niektórych gatunków używa się określonego **hasła przedmiotowego (650)**. Aby znaleźć wskazówki, należy zapoznać się z aneksem **Tytuł ujednolicony - Hasło przedmiotowe** w **Wytycznych**.  
   
-_Przykłady:_  
+##### Przykłady  
 Symphonies  
  Allemandes  
   
@@ -62,7 +62,7 @@ Wprowadzić oznaczenie tempa jeżeli nie można ustalić gatunku. Jeżeli żadna
  - Utwory (utwór generyczny)  
  - Części (pojedyncza część utworu instrumentalnego bez oznaczenia tempa i o nieustalonym charakterze)  
   
-_Przykłady:_  
+##### Przykłady  
 Presto  
  Lento
 
@@ -70,7 +70,7 @@ Presto
 
 **Kolekcje**. W takich przypadkach wprowadza się liczbę plus wprowadzony gatunek. Podać cyfrę arabską oznaczającą ile utworów przynależy do danej kolekcji, a następnie podać możliwie najszerszy gatunek.  
   
-_Przykłady:_  
+##### Przykłady  
 25 arii  
 3 utwory instrumentalne  
   

--- a/default/pl/source_260.md
+++ b/default/pl/source_260.md
@@ -38,7 +38,7 @@ Należy zwrócić uwagę na fakt, że w przypadku rękopisów daty podaje się b
 
 Inne daty można wprowadzać takie, jakie podano w źródle. Informacje niepewne należy oznaczyć znakami zapytania.
 
-_Przykłady:_  
+##### Przykłady  
 1875  
 Boże Narodzenie 1856   
 1757-01-11  

--- a/default/pl/source_588.md
+++ b/default/pl/source_588.md
@@ -6,7 +6,7 @@ W tym polu podaje się, z którego konkretnie egzemplarza korzystano, aby skatal
 
 Podać siglum biblioteki i sygnaturę użytej edycji drukowanej. Można podać, czy skorzystano z danego egzemplarza jedynie po to, aby stworzyć lub uzupełnić fragment rekordu.
 
-_Przykłady:_
+##### Przykłady
 
 - CZ-Nlob X A a 12
 - (incipity:) US-BETm LCM 242

--- a/default/pl/source_594.md
+++ b/default/pl/source_594.md
@@ -61,7 +61,7 @@ Basso continuo
 
 Partie podawać w kolejności od najwyższego do najniższego zakresu. W jednej linii należy podawać tylko jeden instrument. Alternatywne możliwości obsadowe w stosunku do wymagań oryginalnych należy podawać w nawiasach. 
 
-_Przykłady:_
+##### Przykłady
 
 S  
 A  
@@ -86,7 +86,7 @@ org
 
 Tutaj należy podać łączną liczbę głosów. Jeżeli utwór zawiera dwa głosy na ten sam instrument, należy w polu **Obsada** wpisać jeden instrument i liczbę 2 w polu **Liczba**.
 
- _Przykłady:_  
+ ##### Przykłady  
 vl         2 [dla utworu na skrzypce 1 i skrzypce 2]  
 vla        1 [tylko 1 partia na altówkę]  
 ob        2 [obój 1 i obój 2]  

--- a/default/pl/source_657.md
+++ b/default/pl/source_657.md
@@ -2,7 +2,7 @@
 
 Wprowadzić odniesienia do liturgicznego wykorzystania kompozycji. Dotyczy to liturgicznych świąt, uroczystości, obchodów, okresów świątecznych, dni i innych świąt religijnych. Pole połączono linkiem z indeksem **Święta liturgiczne**. W przypadku gdy danego święta liturgicznego nie ma w systemie, należy skontaktować się z Biurem Centralnym RISM.
 
-_Przykłady:_  
+##### Przykłady  
 
 Nativitas Domini
 

--- a/default/pl/source_852.md
+++ b/default/pl/source_852.md
@@ -13,7 +13,7 @@ Wprowadzić siglum biblioteki przechowującej. Pole połączono z plikiem autory
 Wprowadzić bardzo szczegółową informację lokalizacyjną, szczególnie w przypadku dużych bibliotek, jeżeli ich nazwa nie występuje w samym siglum. Wprowadzić nazwę działu w języku lokalnym. Można w nawiasach kwadratowych wpisać tłumaczenie we własnym języku katalogowania.
 
    
-_Przykłady:_  
+##### Przykłady  
 Music Department  
 Collezioni speciali  
 Zakład Zbiorów Muzycznych [Dział muzyczny]
@@ -30,7 +30,7 @@ Uwaga: W polu **Uwaga o proweniencji (561)** wpisać znaki własności.
 
 Pole to jest dostępne w informacji o zbiorach dla nut drukowanych. Jeśli opisywany egzemplarz jest niekompletny, należy wprowadzić części (używając skrótów RISM) lub tomy znajdujące się w Państwa posiadaniu. Jeśli wiedzą Państwo, że egzemplarz jest kompletny, dobrze jest wpisać w polu kompletny - complete. Należy używać angielskiej terminologii. Kompletność odnosi się do obecności wszystkich spodziewanych części lub tomów; inne stopnie niekompletności (np. brakujące strony) można podać w uwadze.
 
-_Przykłady:_  
+##### Przykłady  
 vl only  
 Coro S, A, B only  
 vol. 1, 3 only  
@@ -42,7 +42,7 @@ complete
 
 W tym polu należy wprowadzić sygnaturę. Dokonać jak najdokładniejszej transkrypcji, włącznie ze spacjami i interpunkcją. W obrębie danej kolekcji bibliotecznej sygnatury muszą być spójne. Wskazać znaki pisane w indeksie górnym za pomocą znaku | (pionowa kreska). W przypadku braku sygnatury, należy wpisać **[bez sygnatury - without shelfmark]**. Wprowadzić dodatkowe sygnatury w polu **Inne sygnatury (591)**.
 
-_Przykłady:_  
+##### Przykłady  
 Ms Mus 165/6  
 Mus.ms. 743  
 Th.mus.A 5  

--- a/default/pl/source_856.md
+++ b/default/pl/source_856.md
@@ -9,7 +9,7 @@ Wprowadzić adres URL zasobu zewnętrznego. Zawsze stosować permalinki.
 Pole wymagane przy wprowadzaniu linku do zasobu zewnętrznego.   
 Wprowadzić krótki opis, który wyjaśnia, dlaczego dany adres URL jest istotny w odniesieniu do opisywanego źródła. Należy stosować własny język katalogowania. 
 
-_Przykłady:_  
+##### Przykłady  
 Egzemplarz zdigitalizowany  
 Znak wodny na str. 4  
 Strona główna projektu  

--- a/default/pl/work_400.md
+++ b/default/pl/work_400.md
@@ -13,7 +13,7 @@ Pola te będą identyczne jak w przypadku głównego Nagłówka (100) powyżej.
 #### Tytuł utworu (400 $t)
 Użyj tego pola, aby zapisać warianty tytułu, alternatywy, pseudonimy, różne pisownie itp. Powtórz to pole dla każdej odmiany.
 
-_Przykłady:_  
+##### Przykłady  
 Why fair maid in ev'ry feature  
 Why fair maid in every feature  
 Verrückte Jane  

--- a/default/pt/cat_collections.md
+++ b/default/pt/cat_collections.md
@@ -110,7 +110,7 @@ Há duas maneiras de catalogar periódicos que contêm música: como uma coletâ
   
 
 Catalogar como **coletâneas** pode ser apropriado quando o periódico consiste de música no todo ou em sua maior parte e foi preservado integralmente. O material é associado ao nível de coletânea. Entradas individuais são criadas para cada peça no volume.  
-_Exemplo_:  
+##### Exemplo:  
 1001097294: Edição de Janeiro (ano preciso desconhecido) do Kleine Pianoforte-Bibliothek, contendo 5 peças. Há um registro para o registro principal da coletânea e cinco registros individuais para cada peça.   
 
   
@@ -126,7 +126,7 @@ O RISM inclui música encontrada em publicações impressas que não são essenc
 
   
 
-_Exemplo_:   
+##### Exemplo:   
 990026614: 3 canções de John Isaac Hawkins que foram publicadas no Discourse introductory to a course of lectures on the science of nature (1800), de Charles Willson Peale.  
 **Compositor/Autor (100)**: O compositor da música  
 **Nome de Pessoa Adicional (700)**: O autor do livro, com o indicador other  

--- a/default/pt/cat_printed.md
+++ b/default/pt/cat_printed.md
@@ -84,7 +84,7 @@ A música impressa apresenta títulos distintivos mais frequentemente do que a m
 **Ortografia****  **  
 Insira os títulos uniformes usando ortografia moderna, mas não corrija usos arcaicos ou dialetos/regionalismos. Alterações frequentes incluem v para u, i para j, y para i, e uu para w. A Redação Central pode ajudar no caso de línguas estrangeiras pouco conhecidas. Variações adicionais podem ser inseridas no campo **Título adicional (730)**.   
 
-_Exemplo_:   
+##### Exemplo:   
 RISM A/I: RR 3030c   
 Título na fonte: Musicalische Grab=schrifft.   
 Título uniforme: Musikalische Grabschrift

--- a/default/pt/institution_110.md
+++ b/default/pt/institution_110.md
@@ -40,7 +40,7 @@ F-Pn = France, Paris, Bibliothèque nationale de France, Département de la Musi
 
 No caso de coleções privadas, o último nome do proprietário é adicionado ao código de cidade em letras minúsculas.
 
-_Exemplo_:  
+##### Exemplo:  
 I-PEbattisti = Italy, Perugia, Biblioteca privata Renzo Battisti.
 
 O RISM usa siglas de instituições desde sua fundação em 1952 em todas as suas publicações e catálogos. Elas são também utilizadas em todas enciclopédias musicais internacionais padrão e em publicações musicológicas.

--- a/default/pt/institution_551.md
+++ b/default/pt/institution_551.md
@@ -2,5 +2,5 @@
 
 Insira nomes geográficos. Este campo é ligado ao índice **Locais**. ** **  
   
-_Exemplo_:  
+##### Exemplo:  
 Aigen-Schlägl _para o registro da sigla de instituição RISM A-SCH._

--- a/default/pt/institution_680.md
+++ b/default/pt/institution_680.md
@@ -6,7 +6,7 @@ Insira notas adicionais que descrevam a instituição, tais como:
 - Classificação da coleção, tal como “Coleção em GB-Lbl”
 - Repositório online: URL do repositório digital da instituição
 - Acervo arquivístico e outros acervos (ISDIAH 5.3.7): Insira os nomes dos fundos e coleções. Inicie cada nome em uma nova linha. Use o nome tal como utilizado pela instituição. No caso de fundos pessoais, é recomendável adicionais entre parênteses as datas de nascimento e morte da pessoa em questão. Se existm listas ou URLs com informação sobre as coleções  ou fundos de uma instituição específica, forneça o URL.   
-_Exemplos:_  
+##### Exemplos  
   Joachim, Joseph (1831-1907) (Royal College of Music, Library)  
   Andrée-Stenhammararkivet  
   Telemann, Georg Michael  

--- a/default/pt/person_856.md
+++ b/default/pt/person_856.md
@@ -12,6 +12,6 @@ Nota sobre recurso externo (856 $y)
 
 Descreva brevemente para o que o URL aponta, em uma linguagem relevante.
 
-_Exemplo_:  
+##### Exemplo:  
 [http://resolver.staatsbibliothek-berlin.de/SBB0000B43D00000000  
 ](http://resolver.staatsbibliothek-berlin.de/SBB0000B43D00000000)Schriftprobe [D-B Am.B 65 / p. 1, 26]

--- a/default/pt/publication_020.md
+++ b/default/pt/publication_020.md
@@ -2,6 +2,6 @@
 
 Insira o _International Standard Book Number_ (ISBN). O ISBN é um número que consiste de 10 ou 13 dígitos.
 
-_Exemplos:_  
+##### Exemplos  
 3-486-21584-1  
 978-3-486-21584-1

--- a/default/pt/publication_022.md
+++ b/default/pt/publication_022.md
@@ -1,6 +1,6 @@
 **#### ISSN (022 $a)**Insira o _International Standard Serial Number_ (ISSN). O ISSN identifica unicamente publicações seriadas. 
 
-_Exemplos:_  
+##### Exemplos  
 0027-4380  
 0003-0139  
 1068-2724

--- a/default/pt/publication_024.md
+++ b/default/pt/publication_024.md
@@ -2,6 +2,6 @@
 
 Insira aqui o _International Standard Music Number_ (ISMN). O ISMN é um identificador único para música impressa.  
   
-_Exemplos:_  
+##### Exemplos  
 979-0-9020000-9-3  
 M-2306-7118-7

--- a/default/pt/publication_210.md
+++ b/default/pt/publication_210.md
@@ -18,7 +18,7 @@ _Normalmente o nome do compositor ou do local, caso contrário selecione outra p
 - **Espaço**   
 - **Ano** de publicação
 
-_Exemplos:_
+##### Exemplos
 
 > Pieter Dirksen, _Heinrich Scheidemann’s Keyboard Music: Transmission, Style and Chronology_ (Aldershot: Ashgate, 2007).  
 >             → DirksenS 2007  
@@ -32,7 +32,7 @@ _Exemplos:_
   
 
 Para autores ou editores que publicam múltiplos artigos sobre o mesmo compositor ou obras múltiplas do mesmo compositor, adiciona-se uma letra (**a**, **b**, **c**, etc.) logo após o ano.  
-_Exemplos:_  
+##### Exemplos  
 
 > Anton Cajetan Adlgasser, _Litaniae de venerabili altaris sacramento in B-Dur (WV 3.53),_ ed. Armin Kircher (Stuttgart: Carus, 2005).  
 >             → KircherA 2005  
@@ -54,7 +54,7 @@ _Exemplo:_
 
 Se nenhum autor é indicado, use 1-2 palavras chave retiradas do título em seu lugar.  
 
-_Exemplo__:_
+##### Exemplo_:_
 
 > _Verzeichnis der von dem verstorbenen Grossh. Badischen Prof. der Rechte und Geheimrathe Dr. Anton Friedrich Justus Thibaut zu Heidelberg hinterlassenen Musikaliensammlung welche als ein Ganzes ungetrennt veräussert werden soll_ (Heidelberg, 1842).  
 >             → VerzeichnisThibaut 1842
@@ -62,20 +62,20 @@ _Exemplo__:_
   
 
 Para obras em vários volumes, que foram publicados ao longo de vários anos, apenas o primeiro ano é usado.  
-_Exemplo__:_
+##### Exemplo_:_
 
 > Otto Schröder, _J. Walter: Sämtliche Werke,_ 6 vols. (Kassel: Bärenreiter, 1943-73).  
 >             → SchröderW 1943
 
 Se o ano de edição não for dado ou certo, escreva  s.d. (para no date) em vez de um ano.  
-_Exemplo__:_
+##### Exemplo_:_
 
 > Josef Gregor Zangl, _Der katholische Orgelfreund aus Tyrol: Sammlung von 26 Orgelstücken verschiedener Gattung _ (Innsbruck, no date).  
 >             → ZanglO s.d.
 
   
 Se apenas uma data aproximada de publicação for conhecida, adicione um **ca.** (para circa) quando inserir o editor e ano de publicação no registro, mas omita o “ca.” no título abreviado.   
-_Exemplo__:_  
+##### Exemplo_:_  
 
 > Philipp Fahrbach (der Ältere), _Kärnthner-Lieder Walzer für das Piano-Forte [...] op. 230_ (Vienna, C.A. Spina, ca. 1850).  
 >             → FahrbachK 1850
@@ -94,7 +94,7 @@ Não é necessário indicar o ano.
 
 Um catálogo que foi publicado como parte de um item maior, como um apêndice num livro, pode ser inserido como um catálogo de obras. Tais itens podem também ser citados como uma **Referência bibliográfica (691)**.  
 
-_Exemplos:_
+##### Exemplos
 
 > A. Craig Bell, _Handel: Chronological Thematic Catalogue_ (Darley: Grain-Aig Press, 1972).  
 >             → BelH  
@@ -107,7 +107,7 @@ _Exemplos:_
 
 Use as abreviaturas já estabelecidas para catálogos de obras, se elas existem (BWV, KV, Hob., etc.). Pode-se também usar a abreviatura usada no próprio catálogo, desde que isso não leve a confusão.     
 
-_Exemplos:_  
+##### Exemplos  
 
 > Horst Augsbach, Quantz-Werkverzeichnis (Stuttgart: Carus, 1997).  
 >            → QV  

--- a/default/pt/publication_502.md
+++ b/default/pt/publication_502.md
@@ -2,6 +2,6 @@
 
 Se o item é uma dissertação, inclua o tipo de grau, instituição e ano.
 
-_Exemplos:_  
+##### Exemplos  
 Ph.D. diss., University College, London 1998  
 Diss., Freie Universität, Berlin 2002

--- a/default/pt/publication_520.md
+++ b/default/pt/publication_520.md
@@ -2,6 +2,6 @@
 
 Este campo apresenta a(s) data(s) de início/fim de um item, especialmente para periódicos.
 
-_Exemplos:_  
+##### Exemplos  
 Vol. 1, no. 1 (Apr. 1981)-  
 1969-2004

--- a/default/pt/publication_650.md
+++ b/default/pt/publication_650.md
@@ -5,7 +5,7 @@ Insira um cabeçalho de assunto ou palavra-chave que ajude a descrever os conte�
 
 Localidades geográficas são inseridas no campo **Local relacionado (651)**.
 
-_Exemplos:_  
+##### Exemplos  
 Instruments   
 Madrigals   
 Schriftsteller   

--- a/default/pt/publication_710.md
+++ b/default/pt/publication_710.md
@@ -7,6 +7,6 @@ Use somente estas duas funções:
 - **Editor:** Use especialmente se o item tem uma instituição como autor ao invés de pessoas.
 - **Outra função**
 
-_Exemplos:_  
+##### Exemplos  
 Sing-Akademie zu Berlin   
 Historische Sektion der Bayerischen Benediktinerakademie

--- a/default/pt/publication_760.md
+++ b/default/pt/publication_760.md
@@ -20,7 +20,7 @@ vol. 3/1-2; 11/1-2
 
 Para um capítulo de uma coleção de ensaios, insira os números da página inicial e da página final do capítulo_._
 
-_Exemplo_:  
+##### Exemplo:  
 p. 76-109
 
 Como regra geral, certifique-se de incluir informação suficiente para que quaisquer pessoas sejam capazes de encontrar o item por si mesmas.

--- a/default/pt/publication_856.md
+++ b/default/pt/publication_856.md
@@ -7,7 +7,7 @@ Insira o URL do recurso externo. Use permalinks sempre que possível.
 
 Insira uma breve nota que descreva o link.
 
-_Exemplos:_  
+##### Exemplos  
 Electronic resource  
 Elektronische Ressource  
 Recurso eletrônico  

--- a/default/pt/source_031.md
+++ b/default/pt/source_031.md
@@ -11,7 +11,7 @@ O número de incipit consiste de três dígitos, os quais representam obra, movi
 
 Numere os incipits consecutivamente, mesmo se movimentos estiverem faltando na fonte. Por exemplo, se a fonte é uma sinfonia de três movimentos, mas o movimento intermediário está faltando, os incipits deverão ser numerados 1.1.1 e 1.2.1 (e não 1.3.1). (Nota: Os pontos entre os números são automaticamente adicionados pelo Muscat.)
 
-_Exemplos:_  
+##### Exemplos  
 1.1.1 = 1ª obra, 1º movimento, 1º incipit  
 1.1.2 = 1ª obra, 1º movimento, 2º incipit (soa ao mesmo tempo que 1.1.1)  
 1.1.2 = 1ª obra, 1º movimento, entrada da parte vocal  
@@ -72,7 +72,7 @@ Selecione a tonalidade ou modo na lista.
 
 Insira **x** para tonalidades em sustenido ou **b** para tonalidades em bemóis, seguidas de letras maiúsculas das notas a serem alteradas para cima ou para baixo. Se uma peça está claramente em uma certa tonalidade mas um sustenido ou bemol não está na armadura de clave, os sustenidos ou bemóis omitidos podem ser adicionados entre colchetes. Se não há armadura de clave, deixe o campo em branco.
 
-_Exemplos:_  
+##### Exemplos  
 xF = Fá sustenido = Sol maior ou Mi menor  
 bBE = Si e Mi bemóis = Si bemol maior ou Sol menor  
 xFC[G] = Fá e Dó são sustenidos na fonte, mas a peça é claramente em Lá maior, então o último sustenido é adicionado entre colchetes
@@ -94,7 +94,7 @@ c.** = tempus imperfectum cum prolatione perfecta
 
 Se o metro muda constantemente, pode-se escrever a primeira fórmula de compasso seguida pela segunda, separada por um espaço. Se o incipit está sem indicação de compasso, deixe este campo em branco.
 
-_Exemplos:_  
+##### Exemplos  
 4/4  
 6/8  
 3/4 4/4
@@ -197,7 +197,7 @@ _Exemplo:_
    
 O valor da duração total do grupo deve ser escrito antes do parêntese de abertura **(**. O valor rítmico da primeira nota deve ser colocado depois do parêntese de abertura **(**, mesmo se é idêntico ao da nota imediatamente anterior à seção do ritmo especial. O número de notas no interior do grupo deve ser indicado antes do parêntese de fechamento **)**. Ele é separado da última nota por um ponto e vírgula **;**.
 
-_Exemplos:_  
+##### Exemplos  
 8(3ABCDE;5)   = quiáltera de cinco, com cinco fusas, no espaço de uma colcheia  
 8({3ABCDE};5) = quiáltera de cinco, com cinco fusas, no espaço de uma colcheia, bandeirolas unidas  
 
@@ -242,7 +242,7 @@ A sequência rítmica termina assim que um valor rítmico diferente apareça.
 
 Use **%** para mudar de clave, **$** para mudar a tonalidade ou modo, e **@** para mudar a indicação de compasso. Estes sinais devem ser seguidos da nova indicação (tempo, tonalidade ou clave), seguida por um espaço.
 
-_Exemplos:_  
+##### Exemplos  
 %C-1 '2A  
 %C-1 $xFC '8B  
 @3/2 '1C  
@@ -276,6 +276,6 @@ Adicione quaisquer comentários, tais como a afinação de instrumentos transpos
 
 Neste campo, pode-se indicar a formação instrumental específica para o movimento particular em questão (tal como um movimento dentro de uma peça vocal complexa). Liste a formação instrumental em uma linha usando as abreviaturas de instrumentos do RISM e na ordem padronizada (descrita em **Síntese da formação instrumental [240 $m]**). Use um ponto e vírgula para separar famílias de instrumentos..
 
-_Exemplos:_   
+##### Exemplos   
 S (Enrico), T (Vanoldo); vl 1, 2, b; [winds]  
 S 2 solo; Coro; ob obl; strings, bc

--- a/default/pt/source_240.md
+++ b/default/pt/source_240.md
@@ -24,7 +24,7 @@ Um título uniforme pode ser gerado a partir do seguinte, na ordem de preferênc
   
  Nomes populares ou apelidos (tais com "Eroica" ou "Nelson Mass") não contam como títulos uniformes. Tais nomes são inseridos no campo **Títulos adicionais** **(730 $a)**.   
   
-_Exemplos:_  
+##### Exemplos  
 Die Forelle  
  Die Zauberflöte  
  The beggar's opera  
@@ -42,14 +42,14 @@ Insira o incipit literário como o título uniforme para peças vocais se não e
   
 Certifique-se de que o incipit literário neste campo é idêntico ao incipit literário no campo **Incipit literário (031 $t)**. Para textos latinos, use o texto que precede o ponto e vírgula como título uniforme, mas utilize o incipit literário inteiro para o incipit literário.   
   
-_Exemplos:_  
+##### Exemplos  
 Der Mond ist aufgegangen  
  Gloria [com incipit literário: Gloria, in excelsis Deo et in terra pax]  
   
 3. **Gênero**  
 Use o gênero da obra como o título uniforme se não houver nem um título distintivo, nem um incipit literário. Na maioria dos casos, insere-se o gênero em inglês e no plural (como em **Operas**). Observe que, para alguns gêneros, um determinado **Cabeçalho de Assunto (650)** é utilizado. Por favor, consulte o apêndice **Título uniforme – Cabeçalho de Assunto** nas Diretrizes para ajuda.   
   
-_Exemplos:_  
+##### Exemplos  
 Symphonies  
  Allemandes  
   
@@ -66,11 +66,11 @@ Presto
 **Regras especiais:**
 
 - **Coletâneas e**. Coletâneas. Nestes casos, um número mais o gênero é inserido. Insira um número arábico indicando quantas obras pertencem à coletânea, seguido de um gênero que seja o mais abrangente possível.  
-_Exemplos:_    
+##### Exemplos    
 25 Arias  
 3 Instrumental pieces
 - **Volumes compostos**. Insira um número correspondente ao número de itens envolvidos mais a palavra “Itens”.  
-_Exemplos:_  
+##### Exemplos  
 11 Itens   
 - **Variações.** Insira **Variations** como o título uniforme aqui. No campo **Título adicional (730)**, insira a obra sobre a qual a peça se baseia, quando conhecida, e selecione **Variations** em **Definição de arranjo**.
 - **Inserções.** Insira o incipit literário da peça inserida como título uniforme aqui. No campo **Título adicional (730)**, insira o nome da ópera ou da obra maior no campo.

--- a/default/pt/source_260.md
+++ b/default/pt/source_260.md
@@ -38,7 +38,7 @@ Note que para manuscritos, as datas são inseridas sem colchetes, porque manuscr
 
 Outras datas podem ser indicadas como na fonte. Use um ponto de interrogação para indicar informação incerta.
 
-_Exemplos:_  
+##### Exemplos  
 1875  
 Dia de Natal 1856  
 1757-01-11  

--- a/default/pt/source_340.md
+++ b/default/pt/source_340.md
@@ -22,7 +22,7 @@ Quaisquer acréscimos ou comentários sobre a técnica de impressão pode ser in
 
 Se uma fonte inclui múltiplas técnicas de impressão, pode-se repetir o campo para indicar cada uma das técnicas. Inclua uma nota no campo **Nota geral (500 $a)** para explicar.
 
-_Exemplo_:  
+##### Exemplo:  
 Música gravada que tem uma página de título litografada  
 **Técnica especial de produção (340 $d)**: Gravação  
 **Técnica especial de produção (340 $d)**: Litografia  

--- a/default/pt/source_506.md
+++ b/default/pt/source_506.md
@@ -2,7 +2,7 @@
 
 Termos e condições da instituição possuidora do item podem ser inseridos aqui. Use seu idioma de catalogação.
 
-_Exemplos:_  
+##### Exemplos  
 Consultation in the reading room.  
 Reproductions upon request (charges may apply).  
 Consulta somente na sala de leitura.

--- a/default/pt/source_588.md
+++ b/default/pt/source_588.md
@@ -5,7 +5,7 @@ Este campo especifica qual item físico foi consultado para catalogar uma ediç�
 #### Exemplar examinado para catalogação (588 $a)
 Insira a sigla da instituição e o código ou número de chamada da edição impressa consultada. Pode-se também indicar se foi utilizado um exemplar apenas para uma parte do registro, tal como em incipits ou entradas individuais.
 
-_Exemplos:_
+##### Exemplos
 
 - CZ-Nlob X A a 12
 - (incipits:) US-BETm LCM 242

--- a/default/pt/source_594.md
+++ b/default/pt/source_594.md
@@ -61,7 +61,7 @@ Basso continuo [Baixo continuo]
 
 Liste as partes da mais aguda para a mais grave. Entre com um instrumento por linha. Adicione possibilidades alternativas à formação instrumental original entre parênteses.
 
-_Exemplos:_
+##### Exemplos
 
 S  
 A  

--- a/default/pt/source_595.md
+++ b/default/pt/source_595.md
@@ -27,5 +27,5 @@ Drei Knaben
 
 Insira os papéis dramáticos que aparecem na fonte se eles se diferenciam, na grafia, da forma normalizada fornecida acima.   
   
-_Exemplo_:  
+##### Exemplo:  
 Pappageno

--- a/default/pt/source_597.md
+++ b/default/pt/source_597.md
@@ -4,5 +4,5 @@
 
 Para itens impressos, insira o colofão tal como ele aparece na fonte, tipicamente na última página impressa.
 
-_Exemplo_:  
+##### Exemplo:  
 Vigilie maiores minoresqz ac vespere mortuorū:ānexis officijs | eorundem expliciunt feliciter. Anno dñi.M.cccc.xcij.kł.ij.aprilis

--- a/default/pt/source_657.md
+++ b/default/pt/source_657.md
@@ -2,7 +2,7 @@
 
 Insira referências sobre o uso litúrgico da composição neste campo. Isto inclui festas litúrgicas, festivais, celebrações, estações, dias e outros feriados religiosos. Este campo é ligado ao índice **Festas litúrgicas**. Se uma festa litúrgica necessária para a descrição da fonte ainda não estiver no índice, por favor entre em contato a Redação Central do RISM.
 
-_Exemplos:_  
+##### Exemplos  
 Nativitas Domini  
 Mariae (B.V.) Visitatio  
 

--- a/default/pt/source_852.md
+++ b/default/pt/source_852.md
@@ -16,7 +16,7 @@ Insira a sigla da instituição detentora da fonte. Este campo é relacionado ao
 Insira informação mais específica de localização, em particular para grandes bibliotecas e instituições, se não estiverem referidas na própria sigla. Insira o nome do departamento no idioma local. Pode-se incluir, entre colchetes, uma tradução no seu idioma de catalogação.
 
    
-_Exemplos:_  
+##### Exemplos  
 Music Department  
 Collezioni speciali  
 Zakład Zbiorów Muzycznych [Music department]
@@ -27,7 +27,7 @@ Este campo pode ser usado para indicar o nome de uma coleção especial da qual 
 
 Utilize o idioma local. Pode-se incluir, entre colchetes, uma tradução no seu idioma de catalogação.
 
-_Exemplo_:  
+##### Exemplo:  
 Sammlung Hanns J. Eller
 
 Nota: Insira marcas de propriedade no campo **Nota de proveniência** **(561)**.
@@ -36,7 +36,7 @@ Nota: Insira marcas de propriedade no campo **Nota de proveniência** **(561)**.
 
 Este campo está disponível na informação de material para música impressa. Ao catalogar um exemplar que está incompleto, insira somente as partes (usando as abreviaturas RISM) ou volumes existentes nele. Ao catalogar um exemplar que está completo, será útil indicar **complete** neste campo. Utilize a terminologia em inglês. Aqui, completude diz respeito à presença de todas as partes ou volumes esperados; outros graus de incompletude (como no caso de páginas perdidas) podem ser indicados em uma nota.
 
-_Exemplos:_  
+##### Exemplos  
 vl only  
 Coro S, A, B only  
 vol. 1, 3 only  
@@ -48,7 +48,7 @@ complete
 
 Insira o código, cota ou número (também chamado “número de chamada”) que indica a fonte neste campo. Transcreva o mais precisamente possível, incluindo espaços e pontuação. Insira o código, cota ou número consistentemente no interior de uma dada coleção/acervo. Indique caracteres sobrescritos com | (a barra vertical). Se nenhum código, cota ou número estiver presente, insira **[without shelfmark]**. Insira códigos, cotas ou números adicionais, em uso, no campo **Outros Códigos (591)**.  
 
-_Exemplos:_  
+##### Exemplos  
 Ms Mus 165/6  
 Mus.ms. 743  
 Th.mus.A 5  

--- a/default/pt/source_856.md
+++ b/default/pt/source_856.md
@@ -34,19 +34,19 @@ Este campo é obrigatório quando se insere um link para um recurso externo. Sel
 
 **Fonte digitalizada**: O link é dirigido para um website externo que é uma cópia digitalizada do recurso a ser descrito. Links para repositórios institucionais são preferenciais, mas, caso nenhum esteja disponível, então links para repositórios externos, como o Internet Archive ou o IMSLP, são permitidos. 
 
-_Exemplo_:   
+##### Exemplo:   
 [https://mirador.acdh.oeaw.ac.at/musikarchivspitz/A-SPD\_A15/](https://mirador.acdh.oeaw.ac.at/musikarchivspitz/A-SPD_A15/) 
 
 - 
 
 **Manifesto IIIF**: O objeto ligado é um objeto JSON legível por máquina, processado por um visualizador de documentos interno como o diva.js. O documento está embutido diretamente na página web. Muitas das vezes, “manifest”, “iiif” ou algo semelhante aparece no link. 
 
-_Example_:*[  
+##### Example:*[  
 https://iiif.lib.harvard.edu/manifests/drs:2820650](https://iiif.lib.harvard.edu/manifests/drs:2820650)*
 
 Nos casos em que ambos os links para um visualizador externo e um manifesto IIIF estejam disponíveis, repita o campo e liste ambos os links separadamente.
 
-_Exemplo_: 
+##### Exemplo: 
 
   - Recurso externo: [http://nrs.harvard.edu/urn-3:FHCL.Loeb:537966](http://nrs.harvard.edu/urn-3:FHCL.Loeb:537966)   
 Nota: versão digitalizada   


### PR DESCRIPTION
Changing "Examples" from italics to headings across all languages (global change). This change gets the formatting in the ballpark; more exact adjustments will follow.