### PR TITLE
Adding missing files

### DIFF
--- a/default/guidelines.yml
+++ b/default/guidelines.yml
@@ -14,9 +14,9 @@ chapters:
     - guidelines_title: "cat_language"
       helpfile: "cat_language"
     - guidelines_title: "cat_collections"
-      helpfile: "cat_collections"
+      helpfile: "cat_special_formats"
     - guidelines_title: "cat_templates"
-      helpfile: "cat_templates"
+      helpfile: "cat_new_record"
     - guidelines_title: "cat_authorities"
       helpfile: "cat_authorities"
     - guidelines_title: "scope_printed_music"
@@ -407,7 +407,7 @@ chapters:
           helpfile: "publication_024"
           index: true
         - title: "041"
-          helpfile: "catalogue_041"
+          helpfile: "publication_041"
           index: true
         - title: "044"
           helpfile: "publication_044"

--- a/default/guidelines.yml
+++ b/default/guidelines.yml
@@ -487,8 +487,6 @@ chapters:
     helpfile: "help_titles_keywords"
   - guidelines_title: "aid_texts"
     helpfile: "help_texts_sacred_works"
-  - guidelines_title: "aid_lit"
-    helpfile: "aid_liturgical"
   - guidelines_title: "aid_figured"
     helpfile: "help_figured_bass"
   - guidelines_title: "aid_transpose"

--- a/default/guidelines.yml
+++ b/default/guidelines.yml
@@ -376,8 +376,14 @@ chapters:
         - title: "700"
           helpfile: "publication_700"
           index: true
+        - title: "710"
+          helpfile: "publication_710"
+          index: true
         - title: "240"
           helpfile: "publication_240"
+          index: true
+        - title: "250"
+          helpfile: "publication_250"
           index: true
         - title: "730"
           helpfile: "publication_730"
@@ -387,6 +393,15 @@ chapters:
           index: true
         - title: "300"
           helpfile: "publication_300"
+          index: true
+        - title: "760"
+          helpfile: "publication_760"
+          index: true
+        - title: "780"
+          helpfile: "publication_780"
+          index: true
+        - title: "785"
+          helpfile: "publication_785"
           index: true
         - title: "337"
           helpfile: "publication_337"
@@ -412,26 +427,12 @@ chapters:
         - title: "044"
           helpfile: "publication_044"
           index: true
-        - title: "710"
-          helpfile: "publication_710"
-          index: true
-        - title: "760"
-          helpfile: "publication_760"
-          index: true
         - title: "650"
           helpfile: "publication_650"
           index: true
         - title: "651"
           helpfile: "publication_651"
           index: true
-        - title: "250"
-          helpfile: "publication_250"
-          index: true
-        - title: "780"
-          helpfile: "publication_780"
-          index: true
-        - title: "785"
-          helpfile: "publication_785"
     - guidelines_title: "li_note"
       model: "publication"
       subsections:
@@ -449,7 +450,9 @@ chapters:
           index: true
         - title: "520"
           helpfile: "publication_520"
-          index: true
+          index: true 
+        - title: "590"
+          helpfile: "publication_590"
     - guidelines_title: "li_control"
       model: "publication"
       subsections:
@@ -465,6 +468,8 @@ chapters:
         - title: "005"
           helpfile: "publication_005"
           index: true
+        - title: "981"
+          helpfile: "publication_981"
 
 - guidelines_title: "abbreviations"
   sections:


### PR DESCRIPTION
There are 3 sections that are displaying as `MISSING` and I think it is because the files have been renamed. Sorry, I forgot to mention the renaming. 

https://guidelines-stage.rism.info/cataloguing.html
cat_collections.md renamed to--> cat_special_formats.md
cat_templates.md--> renamed to: cat_new_record.md

cat_special_formats.md: I have called this ## Cataloging special types of sources
cat_new_record.md: I have called this # Records and record types 

https://guidelines-stage.rism.info/li_lit.html
9.2.4 – Language code pointed to the old file `catalogue_041.md` (but they are all called `publications` now).